### PR TITLE
Add part support and remain FG API backwards compatibility

### DIFF
--- a/src/plugins/simulator/flightgear/fgswiftbustrafficproxy.cpp
+++ b/src/plugins/simulator/flightgear/fgswiftbustrafficproxy.cpp
@@ -87,6 +87,26 @@ namespace BlackSimPlugin
                                       planesPositions.headingsDeg, planesPositions.groundSpeedKts, planesPositions.onGrounds);
         }
 
+        void CFGSwiftBusTrafficProxy::setPlanesSurfaces(const PlanesSurfaces &planesSurfaces)
+        {
+            m_dbusInterface->callDBus(QLatin1String("setPlanesSurfaces"),
+                                      planesSurfaces.callsigns, planesSurfaces.gears, planesSurfaces.flaps,
+                                      planesSurfaces.spoilers, planesSurfaces.speedBrakes, planesSurfaces.slats,
+                                      planesSurfaces.wingSweeps, planesSurfaces.thrusts, planesSurfaces.elevators,
+                                      planesSurfaces.rudders, planesSurfaces.ailerons,
+                                      planesSurfaces.landLights, planesSurfaces.taxiLights,
+                                      planesSurfaces.beaconLights, planesSurfaces.strobeLights,
+                                      planesSurfaces.navLights, planesSurfaces.lightPatterns);
+        }
+
+        void CFGSwiftBusTrafficProxy::setPlanesTransponders(const PlanesTransponders &planesTransponders)
+        {
+            m_dbusInterface->callDBus(QLatin1String("setPlanesTransponders"),
+                                      planesTransponders.callsigns, planesTransponders.codes,
+                                      planesTransponders.modeCs, planesTransponders.idents);
+        }
+
+
         void CFGSwiftBusTrafficProxy::getRemoteAircraftData(const QStringList &callsigns, const RemoteAircraftDataCallback &setter) const
         {
             std::function<void(QDBusPendingCallWatcher *)> callback = [ = ](QDBusPendingCallWatcher * watcher)

--- a/src/plugins/simulator/flightgear/fgswiftbustrafficproxy.h
+++ b/src/plugins/simulator/flightgear/fgswiftbustrafficproxy.h
@@ -67,6 +67,7 @@ namespace BlackSimPlugin
                 this->rollsDeg.push_back(situation.getBank().value(BlackMisc::PhysicalQuantities::CAngleUnit::deg()));
                 this->headingsDeg.push_back(situation.getHeading().value(BlackMisc::PhysicalQuantities::CAngleUnit::deg()));
                 this->onGrounds.push_back(situation.getOnGround() == BlackMisc::Aviation::CAircraftSituation::OnGround);
+                this->groundSpeedKts.push_back(situation.getGroundSpeed().value(BlackMisc::PhysicalQuantities::CSpeedUnit::kts()));
             }
 
             QStringList   callsigns;       //!< List of callsigns
@@ -101,12 +102,11 @@ namespace BlackSimPlugin
                 this->rudders.push_back(0.0);
                 this->ailerons.push_back(0.0);
                 this->landLights.push_back(parts.getLights().isLandingOn());
-                //! \todo KB 2019-09 Missing taxi lights in FG
-                // this->taxiLights.push_back(parts.getLights().isTaxiOn());
                 this->beaconLights.push_back(parts.getLights().isBeaconOn());
                 this->strobeLights.push_back(parts.getLights().isStrobeOn());
                 this->navLights.push_back(parts.getLights().isNavOn());
                 this->lightPatterns.push_back(0);
+                this->taxiLights.push_back(parts.getLights().isTaxiOn());
             }
 
             QStringList callsigns;      //!< List of callsigns
@@ -125,6 +125,7 @@ namespace BlackSimPlugin
             QList<bool> strobeLights;   //!< List of strobeLights
             QList<bool> navLights;      //!< List of navLights
             QList<int> lightPatterns;   //!< List of lightPatterns
+            QList<bool> taxiLights;     //!< List of taxi lights
         };
 
         //! Plane Transponders
@@ -212,6 +213,12 @@ namespace BlackSimPlugin
 
             //! Set the position of multiple traffic aircrafts
             void setPlanesPositions(const BlackSimPlugin::Flightgear::PlanesPositions &planesPositions);
+
+            //! Set the surfaces of multiple traffic aircrafts
+            void setPlanesSurfaces(const BlackSimPlugin::Flightgear::PlanesSurfaces &planesSurfaces);
+
+            //! Set the transponders of multiple traffic aircrafts
+            void setPlanesTransponders(const BlackSimPlugin::Flightgear::PlanesTransponders &planesTransponders);
 
             //! Get remote aircrafts data (lat, lon, elevation and CG)
             void getRemoteAircraftData(const QStringList &callsigns, const RemoteAircraftDataCallback &setter) const;

--- a/src/plugins/simulator/flightgear/simulatorflightgear.cpp
+++ b/src/plugins/simulator/flightgear/simulatorflightgear.cpp
@@ -170,8 +170,7 @@ namespace BlackSimPlugin
             {
                 PlanesSurfaces surfaces;
                 surfaces.push_back(callsign, parts);
-                //! \todo KB 2091-09 FG parts sending missing
-                // m_trafficProxy->setPlanesSurfaces(surfaces);
+                m_trafficProxy->setPlanesSurfaces(surfaces);
                 u++;
             }
             return u > 0;
@@ -533,6 +532,15 @@ namespace BlackSimPlugin
                                          newRemoteAircraft.getAircraftIcaoCode().getDesignator(),
                                          newRemoteAircraft.getAirlineIcaoCode().getDesignator(),
                                          livery);
+
+                PlanesPositions pos;
+                pos.push_back(newRemoteAircraft.getSituation());
+                m_trafficProxy->setPlanesPositions(pos);
+
+                PlanesSurfaces surfaces;
+                surfaces.push_back(newRemoteAircraft.getCallsign(), newRemoteAircraft.getParts());
+                m_trafficProxy->setPlanesSurfaces(surfaces);
+
             }
             else
             {
@@ -623,23 +631,25 @@ namespace BlackSimPlugin
 
             // interpolation for all remote aircraft
             PlanesPositions planesPositions;
+            PlanesSurfaces planesSurfaces;
             PlanesTransponders planesTransponders;
 
             int aircraftNumber = 0;
             const bool updateAllAircraft = this->isUpdateAllRemoteAircraft(currentTimestamp);
-            const CCallsignSet callsingsInRange = this->getAircraftInRangeCallsigns();
+            const CCallsignSet callsignsInRange = this->getAircraftInRangeCallsigns();
             for (const CFlightgearMPAircraft &flightgearAircraft : m_flightgearAircraftObjects)
             {
                 const CCallsign callsign(flightgearAircraft.getCallsign());
                 const bool hasCallsign = !callsign.isEmpty();
                 if (!hasCallsign)
                 {
+                    // does not make sense to continue here
                     BLACK_VERIFY_X(false, Q_FUNC_INFO, "missing callsign");
                     continue;
                 }
 
                 // skip no longer in range
-                if (!callsingsInRange.contains(callsign)) { continue; }
+                if (!callsignsInRange.contains(callsign)) { continue; }
 
                 planesTransponders.callsigns.push_back(callsign.asString());
                 planesTransponders.codes.push_back(flightgearAircraft.getAircraft().getTransponderCode());
@@ -660,15 +670,7 @@ namespace BlackSimPlugin
                     if (updateAllAircraft || !this->isEqualLastSent(interpolatedSituation))
                     {
                         this->rememberLastSent(interpolatedSituation);
-                        planesPositions.callsigns.push_back(interpolatedSituation.getCallsign().asString());
-                        planesPositions.latitudesDeg.push_back(interpolatedSituation.latitude().value(CAngleUnit::deg()));
-                        planesPositions.longitudesDeg.push_back(interpolatedSituation.longitude().value(CAngleUnit::deg()));
-                        planesPositions.altitudesFt.push_back(interpolatedSituation.getAltitude().value(CLengthUnit::ft()));
-                        planesPositions.pitchesDeg.push_back(interpolatedSituation.getPitch().value(CAngleUnit::deg()));
-                        planesPositions.rollsDeg.push_back(interpolatedSituation.getBank().value(CAngleUnit::deg()));
-                        planesPositions.headingsDeg.push_back(interpolatedSituation.getHeading().value(CAngleUnit::deg()));
-                        planesPositions.groundSpeedKts.push_back(interpolatedSituation.getGroundSpeed().value(CSpeedUnit::kts()));
-                        planesPositions.onGrounds.push_back(interpolatedSituation.getOnGround() == CAircraftSituation::OnGround);
+                        planesPositions.push_back(interpolatedSituation);
                     }
                 }
                 else
@@ -676,15 +678,35 @@ namespace BlackSimPlugin
                     CLogMessage(this).warning(this->getInvalidSituationLogMessage(callsign, result.getInterpolationStatus()));
                 }
 
+                const CAircraftParts parts(result);
+                if (result.getPartsStatus().isSupportingParts() || parts.getPartsDetails() == CAircraftParts::GuessedParts)
+                {
+                    if (updateAllAircraft || !this->isEqualLastSent(parts, callsign))
+                    {
+                        this->rememberLastSent(parts, callsign);
+                        planesSurfaces.push_back(flightgearAircraft.getCallsign(), parts);
+                    }
+                }
+
             } // all callsigns
+
+            if (!planesTransponders.isEmpty())
+            {
+                m_trafficProxy->setPlanesTransponders(planesTransponders);
+            }
 
             if (!planesPositions.isEmpty())
             {
                 if (CBuildConfig::isLocalDeveloperDebugBuild())
                 {
-                    Q_ASSERT_X(planesPositions.hasSameSizes(), Q_FUNC_INFO, "Mismatching sizes");
+                    BLACK_VERIFY_X(planesPositions.hasSameSizes(), Q_FUNC_INFO, "Mismatching sizes");
                 }
                 m_trafficProxy->setPlanesPositions(planesPositions);
+            }
+
+            if (! planesSurfaces.isEmpty())
+            {
+                m_trafficProxy->setPlanesSurfaces(planesSurfaces);
             }
 
             // stats

--- a/src/plugins/simulator/flightgear/simulatorflightgear.h
+++ b/src/plugins/simulator/flightgear/simulatorflightgear.h
@@ -65,6 +65,8 @@ namespace BlackSimPlugin
 {
     namespace Flightgear
     {
+        extern int FGSWIFTBUS_API_VERSION;
+        extern QList<int> incompatibleVersions;
         class CFGSwiftBusServiceProxy;
         class CFGSwiftBusTrafficProxy;
 


### PR DESCRIPTION
This adds parts support for Flightgear. 

If the API Version 1 is used (which doesn't support parts) no part/transponder-messages are sent.

Fixes #57

