### PR TITLE
Flash taskbar if new important message arrives

### DIFF
--- a/src/blackgui/components/textmessagecomponent.cpp
+++ b/src/blackgui/components/textmessagecomponent.cpp
@@ -32,6 +32,7 @@
 #include "blackmisc/sequence.h"
 #include "blackmisc/verify.h"
 
+#include <QApplication>
 #include <QLayout>
 #include <QLineEdit>
 #include <QPushButton>
@@ -243,6 +244,8 @@ namespace BlackGui
                     if (relevantForMe && audioCsMentioned && ownAircraft.hasCallsign() && message.mentionsCallsign(ownAircraft.getCallsign()))
                     {
                         sGui->getCContextAudioBase()->playNotification(CNotificationSounds::NotificationTextCallsignMentioned, false);
+                        // Flash taskbar icon
+                        QApplication::alert(QWidget::topLevelWidget());
                     }
                 }
                 else if (message.isPrivateMessage())
@@ -250,6 +253,8 @@ namespace BlackGui
                     // private message
                     this->addPrivateChannelTextMessage(message);
                     relevantForMe = true;
+                    // Flash taskbar icon
+                    QApplication::alert(QWidget::topLevelWidget());
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #25 
This flashes the taskbar icon if a private message or a frequency-message arrives, which mentions the own callsign.