### PR TITLE
Various bugfixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,13 +94,18 @@ jobs:
           BITROCK_LICENSE: ${{ secrets.BITROCK_LICENSE }}
       - name: Install dependencies
         run: |
-          sudo apt install doxygen graphviz libglu1-mesa-dev libopus-dev libsodium-dev libpulse-dev libdbus-1-dev libevent-dev
+          sudo apt install dbus-x11 doxygen graphviz libglu1-mesa-dev libopus-dev libsodium-dev libpulse-dev libdbus-1-dev libevent-dev
           sudo cpan Path::Class
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           submodules: true
           fetch-depth: 0
+      - name: Start DBus session bus
+        run: |
+          dbus-launch --sh-syntax | tee session.sh
+          eval $(cat session.sh)
+          echo "::set-env name=DBUS_SESSION_BUS_ADDRESS::$DBUS_SESSION_BUS_ADDRESS"
       - name: Create Vatsim key file
         if: ${{ env.do_vatsim_key == 'true' }}
         run: |

--- a/src/blackcore/corefacadeconfig.cpp
+++ b/src/blackcore/corefacadeconfig.cpp
@@ -77,7 +77,6 @@ namespace BlackCore
     CCoreFacadeConfig CCoreFacadeConfig::allEmpty()
     {
         CCoreFacadeConfig cfg = CCoreFacadeConfig();
-        cfg.m_audio = CCoreFacadeConfig::Local;
         return cfg;
     }
 } // namespace

--- a/src/blackcore/corefacadeconfig.cpp
+++ b/src/blackcore/corefacadeconfig.cpp
@@ -58,25 +58,21 @@ namespace BlackCore
 
     CCoreFacadeConfig CCoreFacadeConfig::forCoreAllLocalInDBus(const QString &dbusBootstrapAddress)
     {
-        const CCoreFacadeConfig cfg(CCoreFacadeConfig::LocalInDBusServer, dbusBootstrapAddress);
-        return cfg;
+        return { LocalInDBusServer, dbusBootstrapAddress };
     }
 
     CCoreFacadeConfig CCoreFacadeConfig::local(const QString &dbusBootstrapAddress)
     {
-        const CCoreFacadeConfig cfg = CCoreFacadeConfig(CCoreFacadeConfig(CCoreFacadeConfig::Local, dbusBootstrapAddress));
-        return cfg;
+        return { Local, dbusBootstrapAddress };
     }
 
     CCoreFacadeConfig CCoreFacadeConfig::remote(const QString &dbusBootstrapAddress)
     {
-        CCoreFacadeConfig cfg = CCoreFacadeConfig(CCoreFacadeConfig(CCoreFacadeConfig::Remote, dbusBootstrapAddress));
-        return cfg;
+        return { Remote, dbusBootstrapAddress };
     }
 
     CCoreFacadeConfig CCoreFacadeConfig::allEmpty()
     {
-        CCoreFacadeConfig cfg = CCoreFacadeConfig();
-        return cfg;
+        return {};
     }
 } // namespace

--- a/src/blackgui/components/downloadcomponent.cpp
+++ b/src/blackgui/components/downloadcomponent.cpp
@@ -190,7 +190,7 @@ namespace BlackGui
             const CUrl download = remoteFile.getSmartUrl();
             if (download.isEmpty())
             {
-                const CStatusMessage msg = CStatusMessage(this, CLogCategory::validation()).error(u"No download URL for file name '%1'") << remoteFile.getNameAndSize();
+                const CStatusMessage msg = CStatusMessage(this, CLogCategory::validation()).error(u"No download URL for file name '%1'") << remoteFile.getBaseNameAndSize();
                 this->showOverlayMessage(msg, CDownloadComponent::OverlayMsgTimeoutMs);
                 return false;
             }

--- a/src/blackgui/components/installxswiftbuscomponent.cpp
+++ b/src/blackgui/components/installxswiftbuscomponent.cpp
@@ -222,7 +222,7 @@ namespace BlackGui
             const CUrl download = rf.getSmartUrl();
             if (download.isEmpty())
             {
-                const CStatusMessage msg = CStatusMessage(this, CLogCategory::validation()).error(u"No download URL for file name '%1'") << rf.getNameAndSize();
+                const CStatusMessage msg = CStatusMessage(this, CLogCategory::validation()).error(u"No download URL for file name '%1'") << rf.getBaseNameAndSize();
                 this->showOverlayMessage(msg, CInstallXSwiftBusComponent::OverlayMsgTimeoutMs);
                 return;
             }
@@ -287,10 +287,10 @@ namespace BlackGui
 
         CRemoteFile CInstallXSwiftBusComponent::getRemoteFileSelected() const
         {
-            const QString fileNameAndSize = ui->cb_DownloadFile->currentText();
+            const QString baseNameAndSize = ui->cb_DownloadFile->currentText();
             const CUpdateInfo update = m_updates.get();
             const CRemoteFileList remoteFiles = update.getArtifactsXSwiftBus().asRemoteFiles();
-            return remoteFiles.findFirstByMatchingNameOrDefault(fileNameAndSize);
+            return remoteFiles.findFirstByMatchingBaseNameOrDefault(baseNameAndSize);
         }
 
         QString CInstallXSwiftBusComponent::downloadDir() const
@@ -331,7 +331,7 @@ namespace BlackGui
             const CRemoteFileList remoteFiles = artifacts.asRemoteFiles();
             if (!remoteFiles.isEmpty())
             {
-                const QStringList xSwiftBusFiles(remoteFiles.getNamesPlusSize(false));
+                const QStringList xSwiftBusFiles(remoteFiles.getBaseNamesPlusSize(false));
                 m_xSwiftBusArtifacts = artifacts;
                 ui->cb_DownloadFile->addItems(xSwiftBusFiles);
 
@@ -340,17 +340,17 @@ namespace BlackGui
                 if (m_defaultDownloadName.isEmpty())
                 {
                     const CRemoteFile rf = remoteFiles.findFirstContainingNameOrDefault(CBuildConfig::getVersionString(), Qt::CaseInsensitive);
-                    if (rf.hasName()) { current = rf.getNameAndSize(); }
+                    if (rf.hasName()) { current = rf.getBaseNameAndSize(); }
                 }
                 else
                 {
-                    const CRemoteFile rf = remoteFiles.findFirstByMatchingNameOrDefault(m_defaultDownloadName);
-                    if (rf.hasName()) { current = rf.getNameAndSize(); }
+                    const CRemoteFile rf = remoteFiles.findFirstByMatchingBaseNameOrDefault(m_defaultDownloadName);
+                    if (rf.hasName()) { current = rf.getBaseNameAndSize(); }
                 }
 
                 ui->cb_DownloadFile->setCurrentText(
                     current.isEmpty() ?
-                    remoteFiles.frontOrDefault().getNameAndSize() :
+                    remoteFiles.frontOrDefault().getBaseNameAndSize() :
                     current
                 ); // latest version
             }

--- a/src/blackgui/components/installxswiftbuscomponent.cpp
+++ b/src/blackgui/components/installxswiftbuscomponent.cpp
@@ -102,7 +102,7 @@ namespace BlackGui
         void CInstallXSwiftBusComponent::installXSwiftBus()
         {
             const CRemoteFile rf = this->getRemoteFileSelected();
-            const QString downloadFileName = CFileUtils::appendFilePathsAndFixUnc(this->downloadDir(), rf.getName());
+            const QString downloadFileName = CFileUtils::appendFilePathsAndFixUnc(this->downloadDir(), rf.getBaseName());
             QPointer<CInstallXSwiftBusComponent> myself(this);
             QFile downloadFile(downloadFileName);
 
@@ -129,7 +129,7 @@ namespace BlackGui
                 return;
             }
 
-            const QString destFileName = CFileUtils::appendFilePathsAndFixUnc(xSwiftBusDirectory, rf.getName());
+            const QString destFileName = CFileUtils::appendFilePathsAndFixUnc(xSwiftBusDirectory, rf.getBaseName());
             {
                 QFile destFile(destFileName);
                 if (destFile.exists())
@@ -199,7 +199,7 @@ namespace BlackGui
         {
             if (!sGui || !sGui->hasWebDataServices() || sGui->isShuttingDown()) { return; }
             const CRemoteFile rf = this->getRemoteFileSelected();
-            if (!rf.getName().contains(CBuildConfig::getVersionString()))
+            if (!rf.getBaseName().contains(CBuildConfig::getVersionString()))
             {
                 const QMessageBox::StandardButton reply = QMessageBox::question(this,
                         "Download XSwiftBus",
@@ -227,7 +227,7 @@ namespace BlackGui
                 return;
             }
 
-            const QString saveAsFile = CFileUtils::appendFilePathsAndFixUnc(ui->le_DownloadDir->text(), rf.getName());
+            const QString saveAsFile = CFileUtils::appendFilePathsAndFixUnc(ui->le_DownloadDir->text(), rf.getBaseName());
             const QFile saveFile(saveAsFile);
             if (saveFile.exists())
             {

--- a/src/blackmisc/dbusserver.cpp
+++ b/src/blackmisc/dbusserver.cpp
@@ -245,7 +245,7 @@ namespace BlackMisc
                 }
                 else
                 {
-                    CLogMessage(this).error(u"Error, no success with session bus registration");
+                    CLogMessage(this).error(u"Error adding '%1' '%2' to session DBus: '%3'") << path << getDBusInterfaceFromClassInfo(object) << connection.lastError().message();
                 }
             }
             break;
@@ -258,7 +258,7 @@ namespace BlackMisc
                 }
                 else
                 {
-                    CLogMessage(this).error(u"Error, no success with system bus registration");
+                    CLogMessage(this).error(u"Error adding '%1' '%2' to system DBus: '%3'") << path << getDBusInterfaceFromClassInfo(object) << connection.lastError().message();
                 }
             }
             break;
@@ -272,7 +272,7 @@ namespace BlackMisc
                     }
                     else
                     {
-                        CLogMessage(this).error(u"Error, no success with %1 registration") << connection.name();
+                        CLogMessage(this).error(u"Error adding '%1' '%2' to P2P DBus '%3': '%4'") << path << getDBusInterfaceFromClassInfo(object) << connection.name() << connection.lastError().message();
                     }
                 }
             }

--- a/src/blackmisc/identifier.cpp
+++ b/src/blackmisc/identifier.cpp
@@ -96,7 +96,7 @@ namespace BlackMisc
     CIdentifier::CIdentifier(const QString &name)
         : ITimestampBased(QDateTime::currentMSecsSinceEpoch()),
           m_name(name.trimmed()),
-          m_machineIdBase64(cachedMachineUniqueId().toBase64()),
+          m_machineIdBase64(cachedMachineUniqueId().toBase64(QByteArray::OmitTrailingEquals)),
           m_machineName(cachedLocalHostName()),
           m_processName(cachedSanitizedApplicationName()),
           m_processId(QCoreApplication::applicationPid())
@@ -133,7 +133,7 @@ namespace BlackMisc
 
     const CIdentifier &CIdentifier::fake()
     {
-        static const CIdentifier id("fake", QByteArrayLiteral("00000000-0000-0000-0000-000000000000").toBase64(), "fake machine", "fake process", 0);
+        static const CIdentifier id("fake", QByteArrayLiteral("00000000-0000-0000-0000-000000000000").toBase64(QByteArray::OmitTrailingEquals), "fake machine", "fake process", 0);
         return id;
     }
 
@@ -170,7 +170,7 @@ namespace BlackMisc
 
     QByteArray CIdentifier::getMachineId() const
     {
-        return QByteArray::fromBase64(m_machineIdBase64.toLocal8Bit());
+        return *QByteArray::fromBase64Encoding(m_machineIdBase64.toLocal8Bit());
     }
 
     QString CIdentifier::toDBusObjectPath(const QString &root) const
@@ -243,7 +243,7 @@ namespace BlackMisc
 
     void CIdentifier::updateToCurrentMachine()
     {
-        m_machineIdBase64 = cachedMachineUniqueId().toBase64();
+        m_machineIdBase64 = cachedMachineUniqueId().toBase64(QByteArray::OmitTrailingEquals);
         m_machineName     = cachedLocalHostName();
     }
 
@@ -296,7 +296,7 @@ namespace BlackMisc
         switch (i)
         {
         case IndexName:               return m_name.compare(compareValue.m_name, Qt::CaseInsensitive);
-        case IndexMachineIdBase64:    return m_machineIdBase64.compare(compareValue.m_machineIdBase64, Qt::CaseInsensitive);
+        case IndexMachineIdBase64:    return m_machineIdBase64.compare(compareValue.m_machineIdBase64);
         case IndexMachineName:        return m_machineName.compare(compareValue.m_machineName, Qt::CaseInsensitive);
         case IndexMachineId:          return m_machineName.compare(compareValue.m_machineName, Qt::CaseInsensitive);
         case IndexProcessId:          return Compare::compare(m_processId, compareValue.m_processId);

--- a/src/blackmisc/identifier.h
+++ b/src/blackmisc/identifier.h
@@ -80,7 +80,7 @@ namespace BlackMisc
         QString toDBusObjectPath(const QString &root = {}) const;
 
         //! Reconstruct an identifier from a DBus object path.
-        CIdentifier fromDBusObjectPath(const QString &path, const QString &root = {});
+        static CIdentifier fromDBusObjectPath(const QString &path, const QString &root = {});
 
         //! Name
         const QString &getName() const { return m_name; }

--- a/src/blackmisc/network/remotefile.cpp
+++ b/src/blackmisc/network/remotefile.cpp
@@ -27,13 +27,13 @@ namespace BlackMisc
             : m_name(name), m_url(url), m_size(size)
         { }
 
-        QString CRemoteFile::getNameAndSize() const
+        QString CRemoteFile::getBaseNameAndSize() const
         {
             if (!this->hasName()) { return {}; }
-            return QStringLiteral("%1 (%2)").arg(this->getName(), this->getSizeHumanReadable());
+            return QStringLiteral("%1 (%2)").arg(this->getBaseName(), this->getSizeHumanReadable());
         }
 
-        bool CRemoteFile::matchesName(const QString &name) const
+        bool CRemoteFile::matchesBaseName(const QString &name) const
         {
             if (name.isEmpty()) { return false; }
             if (caseInsensitiveStringCompare(name, this->getBaseName())) { return true; }

--- a/src/blackmisc/network/remotefile.h
+++ b/src/blackmisc/network/remotefile.h
@@ -66,13 +66,13 @@ namespace BlackMisc
             bool hasName() const { return !m_name.isEmpty(); }
 
             //! Name + human readable size
-            QString getNameAndSize() const;
+            QString getBaseNameAndSize() const;
 
             //! Name
             void setName(const QString &name) { m_name = name.trimmed(); }
 
             //! Matching name?
-            bool matchesName(const QString &name) const;
+            bool matchesBaseName(const QString &baseName) const;
 
             //! Description
             const QString &getDescription() const { return m_description; }

--- a/src/blackmisc/network/remotefilelist.cpp
+++ b/src/blackmisc/network/remotefilelist.cpp
@@ -35,12 +35,12 @@ namespace BlackMisc
             return fileNames;
         }
 
-        QStringList CRemoteFileList::getNamesPlusSize(bool sorted) const
+        QStringList CRemoteFileList::getBaseNamesPlusSize(bool sorted) const
         {
             QStringList fileNames;
             for (const CRemoteFile &rf : *this)
             {
-                fileNames.append(rf.getNameAndSize());
+                fileNames.append(rf.getBaseNameAndSize());
             }
             if (sorted) { fileNames.sort(); }
             return fileNames;
@@ -62,12 +62,12 @@ namespace BlackMisc
             return CRemoteFile();
         }
 
-        CRemoteFile CRemoteFileList::findFirstByMatchingNameOrDefault(const QString &name) const
+        CRemoteFile CRemoteFileList::findFirstByMatchingBaseNameOrDefault(const QString &baseName) const
         {
-            if (name.isEmpty()) { return CRemoteFile(); }
+            if (baseName.isEmpty()) { return CRemoteFile(); }
             for (const CRemoteFile &rf : *this)
             {
-                if (rf.matchesName(name)) { return rf; }
+                if (rf.matchesBaseName(baseName)) { return rf; }
             }
             return CRemoteFile();
         }

--- a/src/blackmisc/network/remotefilelist.h
+++ b/src/blackmisc/network/remotefilelist.h
@@ -45,7 +45,7 @@ namespace BlackMisc
             QStringList getNames(bool sorted = true) const;
 
             //! All file names plus size
-            QStringList getNamesPlusSize(bool sorted = true) const;
+            QStringList getBaseNamesPlusSize(bool sorted = true) const;
 
             //! First by name of default
             CRemoteFile findFirstByNameOrDefault(const QString &name) const;
@@ -54,7 +54,7 @@ namespace BlackMisc
             CRemoteFile findFirstContainingNameOrDefault(const QString &name, Qt::CaseSensitivity cs) const;
 
             //! Find first matching name of default
-            CRemoteFile findFirstByMatchingNameOrDefault(const QString &name) const;
+            CRemoteFile findFirstByMatchingBaseNameOrDefault(const QString &name) const;
 
             //! Find all executable files (decided by appendix)
             CRemoteFileList findExecutableFiles() const;

--- a/src/xswiftbus/traffic.cpp
+++ b/src/xswiftbus/traffic.cpp
@@ -897,6 +897,7 @@ namespace XSwiftBus
 
     void CTraffic::Labels::draw()
     {
+        static const double maxRangeM = 10000;
         static const double metersPerFt = 0.3048;
         static float color[3]{ 1.0f, 0.75f, 0.0f };
         std::array<float, 16> worldMat = m_worldMat.getAll();
@@ -915,6 +916,7 @@ namespace XSwiftBus
             double localPos[4]{};
             double windowPos[4]{};
             XPLMWorldToLocal(planePos.lat, planePos.lon, planePos.elevation * metersPerFt, &worldPos[0], &worldPos[1], &worldPos[2]);
+            if (distanceSquared(worldPos) > maxRangeM * maxRangeM) { continue; }
             matrixMultVec(localPos, worldMat.data(), worldPos);
             matrixMultVec(windowPos, projMat.data(), localPos);
 
@@ -940,6 +942,14 @@ namespace XSwiftBus
         out[1] = v[0] * m[1] + v[1] * m[5] + v[2] * m[9] + v[3] * m[13];
         out[2] = v[0] * m[2] + v[1] * m[6] + v[2] * m[10] + v[3] * m[14];
         out[3] = v[0] * m[3] + v[1] * m[7] + v[2] * m[11] + v[3] * m[15];
+    }
+
+    double CTraffic::Labels::distanceSquared(const double pos[3]) const
+    {
+        const double dx = m_viewX.get() - pos[0];
+        const double dy = m_viewY.get() - pos[1];
+        const double dz = m_viewZ.get() - pos[2];
+        return dx * dx + dy * dy + dz * dz;
     }
 
     int CTraffic::orbitPlaneFunc(XPLMCameraPosition_t *cameraPosition, int isLosingControl, void *refcon)

--- a/src/xswiftbus/traffic.h
+++ b/src/xswiftbus/traffic.h
@@ -198,12 +198,16 @@ namespace XSwiftBus
             virtual void draw() override;
         private:
             static void matrixMultVec(double out[4], const float m[16], const double v[4]);
+            double distanceSquared(const double pos[3]) const;
             CTraffic *m_traffic = nullptr;
             ArrayDataRef<xplane::data::sim::graphics::view::world_matrix> m_worldMat;
             ArrayDataRef<xplane::data::sim::graphics::view::projection_matrix_3d> m_projMat;
             DataRef<xplane::data::sim::graphics::view::window_width> m_windowWidth;
             DataRef<xplane::data::sim::graphics::view::window_height> m_windowHeight;
             DataRef<xplane::data::sim::graphics::view::visibility_effective_m> m_visibilityM;
+            DataRef<xplane::data::sim::graphics::view::view_x> m_viewX;
+            DataRef<xplane::data::sim::graphics::view::view_y> m_viewY;
+            DataRef<xplane::data::sim::graphics::view::view_z> m_viewZ;
         };
         Labels m_labels { this };
 

--- a/tests/blackmisc/testidentifier/testidentifier.cpp
+++ b/tests/blackmisc/testidentifier/testidentifier.cpp
@@ -34,6 +34,9 @@ namespace BlackMiscTest
 
         //! Machine unique id tests
         void machineUniqueId();
+
+        //! Conversion to dbus object path
+        void dbusObjectPath();
     };
 
     //! Test identifiable object
@@ -65,6 +68,15 @@ namespace BlackMiscTest
     {
         CIdentifier o;
         QVERIFY2(!o.getMachineId().isEmpty(), "Machine id shall never be empty! If this test failed on a supported platform, get a fallback solution!");
+    }
+
+    void CTestIdentifier::dbusObjectPath()
+    {
+        QObject q;
+        q.setObjectName("!@#$%^&*()_+");
+        CTestIdentifiable id(&q);
+        QString s(id.identifier().toDBusObjectPath());
+        QVERIFY2(id.identifier() == CIdentifier::fromDBusObjectPath(s), "Conversion from dbus object path and back compares equal");
     }
 
     CTestIdentifiable::CTestIdentifiable(QObject *nameObject) : CIdentifiable(nameObject)


### PR DESCRIPTION
- Fixed `SharedState::CDataLinkDBus` failing on Linux due to invalid object paths.
- Fixed `swiftdata` using audio context, which caused an issue on MacOS.
- xplanemp2 map view: now displaying all planes regardless of mode C.
- xswiftbus labels: set maximum draw distance 10km.
- Fixed downloading xswiftbus from GitHub via setup wizard.