### PR TITLE
Adjusting links to new documentation

### DIFF
--- a/docs/src/mainpage.dox
+++ b/docs/src/mainpage.dox
@@ -26,7 +26,7 @@ Unit and integration tests
 
 \section resources Resources
 
-- <a href="http://www.swift-project.org">swift BLOG website</a>
-- <a href="https://dev.swift-project.org/">swift developer website</a>
+- <a href="https://www.swift-project.org">swift BLOG website</a>
+- <a href="https://github.com/swift-project">swift developer website</a>
 
 */

--- a/docs/src/wiki/developersguide.dox
+++ b/docs/src/wiki/developersguide.dox
@@ -3,6 +3,6 @@
 \page developersguide Developers Guide
 \ingroup developersguide
 
-see developer documentation <a href="https://dev.swift-project.org/w/dev/"> here</a>
+see developer documentation <a href="https://docs.swift-project.org/doku.php?id=developer_documentation"> here</a>
 
 */

--- a/installer/installbuilder/vcredist-x64.xml
+++ b/installer/installbuilder/vcredist-x64.xml
@@ -34,7 +34,7 @@ Error Code: ${program_exit_code}
 Check if another version was already installed and if not, try to run the installer manually from
 ${installdir}\vcredist\
 
-The installation will now continue, but swift might not work properly. If this is the case, raise a bugreport on https://dev.swift-project.org with the error code, you received.</text>
+The installation will now continue, but swift might not work properly. If this is the case, raise a bugreport on https://github.com/swift-project/pilotclient with the error code, you received.</text>
                     <ruleList>
                         <!-- No error -->
                         <compareValues>

--- a/installer/installbuilder/vcredist-x86.xml
+++ b/installer/installbuilder/vcredist-x86.xml
@@ -34,7 +34,7 @@ Error Code: ${program_exit_code}
 Check if another version was already installed and if not, try to run the installer manually from
 ${installdir}\vcredist\
 
-The installation will now continue, but swift might not work properly. If this is the case, raise a bugreport on https://dev.swift-project.org with the error code, you received.</text>
+The installation will now continue, but swift might not work properly. If this is the case, raise a bugreport on https://github.com/swift-project/pilotclient with the error code, you received.</text>
                     <ruleList>
                         <!-- No error -->
                         <compareValues>

--- a/resources/share/legal/about.html
+++ b/resources/share/legal/about.html
@@ -15,7 +15,6 @@
 	<table>
 		<tr>
 			<th colspan="3">
-				<iframe align="right" src="https://duckduckgo.com/search.html?width=200&site=dev.swift-project.org,datastore.swift-project.org,blog.swift-project.net&prefill=Search swift sites" style="overflow:hidden;margin:0;padding:0;width:258px;height:40px;align" frameborder="0"></iframe>
 				swift - the multiple simulator and OS pilot client.
 				We are an independent (private/non-commercial) software project creating open source software for flight simulation.
 			</th>
@@ -24,26 +23,26 @@
 			<td>
 				Download swift:
 				<ul>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/installation/system-requirements/">System requirements</a>
-					<li><a target="_blank" href="https://datastore.swift-project.org/page/publicartifacts.php"><i>swift</i> pilot client</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/alpha/">Tester and developer versions</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/installation/downloadmodels/">Aircraft models (external)</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=installation_and_configuration#system_requirements">System requirements</a>
+					<li><a target="_blank" href="https://github.com/swift-project/pilotclient/releases/latest"><i>swift</i> pilot client</a></li>
+					<li><a target="_blank" href="https://github.com/swift-project/pilotclient/releases">Tester and developer versions</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=download_aircraft_models">Aircraft models (external)</a></li>
 				</ul>
 			</td>
 			<td>
 				Installation:
 				<ul>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/installation/"><i>swift</i> installation</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/swiftgeneral/copyswiftdata/"><i><i>swift</i></i> update</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/useswiftchecklist/">Before 1st flight</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=installation_and_configuration"><i>swift</i> installation</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=installing_new_version_parallel_copy_swift_data_other_versions"><i><i>swift</i></i> update</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=checklist_check_before_1st_flight">Before 1st flight</a></li>
 				</ul>
 			</td>
 			<td>
 				Documentation:
 				<ul>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/"><i>swift</i> help</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/smt/smttutorials/"><i>swift</i> @YouTube</a></li>
-					<li><a target="_blank" href="https://blog.swift-project.net/"><i>swift</i> Blog</a></li>					
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=user_manual"><i>swift</i> help</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=tutorials"><i>swift</i> @YouTube</a></li>
+					<li><a target="_blank" href="http://swift-project.org/blog/"><i>swift</i> Blog</a></li>					
 				</ul>
 			</td>
 		</tr>
@@ -51,25 +50,23 @@
 			<td>
 				Support and contact:
 				<ul>
-					<li><a target="_blank" href="https://forums.vatsim.net/viewforum.php?f=152">VATSIM forum (VATSIM members)</a></li>
+					<li><a target="_blank" href="https://forums.vatsim.net/forum/347-swift/">VATSIM forum (VATSIM members)</a></li>
                                         <li><a target="_blank" href="https://discord.gg/R7Atd9A">Discord channels</a></li>
-					<li><a target="_blank" target="_blank"href="https://dev.swift-project.org/w/help/gi/reportingbugs/">Reporting bugs</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org">Request new model mappings</a></li>
+					<li><a target="_blank" target="_blank"href="https://docs.swift-project.org/doku.php?id=reporting_bugs">Reporting bugs</a></li>
 				</ul>
 			</td>
 			<td>
 				<i>swift</i> testers:
 				<ul>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/gi/">Getting involved</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/alpha/">Download early access versions</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=getting_involved">Getting involved</a></li>
 					<li><a target="_blank" href="https://datastore.swift-project.org"><i>swift</i> model database</a></li>
 				</ul>
 			</td>
 			<td>
 				<i>swift</i> developers:
 				<ul>
-					<li><a target="_blank" href="https://dev.swift-project.org/"><i>swift</i> developer site</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/gi/gettingstarteddev/">Start as developer</a></li>
+					<li><a target="_blank" href="https://github.com/swift-project"><i>swift</i> developer site</a></li>
+					<li><a target="_blank" href="https://docs.swift-project.org/doku.php?id=getting_started_developer">Start as developer</a></li>
 				</ul>
 			</td>
 		</tr>
@@ -78,7 +75,6 @@
 				swift model database:
 				<ul>
 					<li><a target="_blank" href="https://datastore.swift-project.org">Request model mappings</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/help/alpha/">Download early access versions</a></li>
 				</ul>
 			</td>
 			<td>
@@ -88,7 +84,6 @@
 					<li><a href="dataprotection.html">Your data and privacy</a></li>
 					<li><a href="copyright.html">Copyright</a></li>
 					<li><a href="3rdparty.html">3rd party libraries</a></li>
-					<li><a target="_blank" href="https://dev.swift-project.org/w/facts/"><i>swift</i> facts</a>
 				</ul>
 			</td>
 			<td>

--- a/resources/share/legal/data.html
+++ b/resources/share/legal/data.html
@@ -47,7 +47,7 @@
 			<td>
 			In the swift clients you can enable to send crash reports, which will also send technical
 			information such as your IP and hardware info.
-			<a href="https://dev.swift-project.org/w/help/swiftgeneral/crashreports/">Further details are here.</a>
+			<a href="https://docs.swift-project.org/doku.php?id=crash_reports_enable_dumps/">Further details are here.</a>
 			</td>
 			<td>
 			Helps us to improve the quality of swift.
@@ -99,7 +99,7 @@
 		</tr>
 		<tr>
 			<td>
-			Your master data (profile) in <a href="https://datastore.swift-project.org">datastore</a> and in <a href="https://dev.swift-project.org/">Phabricator</a>
+			Your master data (profile) in <a href="https://datastore.swift-project.org">datastore</a>
 			can be self administered. For VATSIM a simplified Single-Sign-On has been established, 
 			sharring the VATSIM data with swift (the password is NOT transferred).
 			</td>
@@ -167,7 +167,7 @@
 			<td>
 			Im swift client kann man crash reports erlauben, bei diesen werden technische Informationen
 			wie Ihre IP Adresse oder Hardware Informationen gesendet.
-			<a href="https://dev.swift-project.org/w/help/swiftgeneral/crashreports/">Weitere Informationen.</a>
+			<a href="https://docs.swift-project.org/doku.php?id=crash_reports_enable_dumps">Weitere Informationen.</a>
 			</td>
 			<td>
 			Hilft uns swift zu verbessern.
@@ -219,7 +219,7 @@
 		</tr>
 		<tr>
 			<td>
-			Die Benutzerstammdaten können im <a href="https://datastore.swift-project.org">datastore</a> und in <a href="https://dev.swift-project.org/">Phabricator</a>
+			Die Benutzerstammdaten können im <a href="https://datastore.swift-project.org">datastore</a>
 			selbst geändert werden. Mit VATSIM ist ein vereinfachtes Single-Sign-On möglich, wobei wir Daten
 			von VATSIM erhalten.
 			</td>

--- a/resources/share/legal/datamisc.html
+++ b/resources/share/legal/datamisc.html
@@ -10,7 +10,6 @@
 	<ul>
 		<li>
 		swift tauscht Daten zwischen seinen einzelnen Web-Anwendungen aus, z.B.
-		<a href="https://dev.swift-project.org/">dev.swift-project.org</a> und 
 		<a href="https://datastore.swift-project.org/">datastore.swift-project.org</a> .
 		</li>
 		<li>
@@ -29,7 +28,6 @@
 	<ul>
 		<li>
 		swift shares data among its own ecosystem, i.e. the various applications like
-		<a href="https://dev.swift-project.org/">dev.swift-project.org</a> and 
 		<a href="https://datastore.swift-project.org/">datastore.swift-project.org</a> .
 		</li>
 		<li>


### PR DESCRIPTION
Fixing old links. Some links still pointing to dev.swift-project.org as there is no suitable replacement (until now). Mainly newsfeed for launcher and comments to old phab issues.