### PR TITLE
Fix regression in fatal log message handler

### DIFF
--- a/src/blackmisc/loghandler.cpp
+++ b/src/blackmisc/loghandler.cpp
@@ -45,8 +45,6 @@ namespace BlackMisc
     //! Qt message handler
     void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message)
     {
-        const CStatusMessage statusMessage(type, context, message);
-        const auto invokee = [statusMessage] { CLogHandler::instance()->logLocalMessage(statusMessage); };
         if (type == QtFatalMsg && CLogHandler::instance()->thread() != QThread::currentThread())
         {
             // Fatal message means this thread is about to crash the application. A queued connection would be useless.
@@ -76,7 +74,10 @@ namespace BlackMisc
 #   endif
         }
 #endif
-        QMetaObject::invokeMethod(CLogHandler::instance(), invokee);
+        QMetaObject::invokeMethod(CLogHandler::instance(), [statusMessage = CStatusMessage(type, context, message)]
+        {
+            CLogHandler::instance()->logLocalMessage(statusMessage);
+        });
     }
 
     void CLogHandler::install(bool skipIfAlreadyInstalled)

--- a/src/blackmisc/loghandler.cpp
+++ b/src/blackmisc/loghandler.cpp
@@ -51,7 +51,7 @@ namespace BlackMisc
         {
             // Fatal message means this thread is about to crash the application. A queued connection would be useless.
             // Blocking queued connection means we pause this thread just long enough to let the main thread handle the message.
-            QMetaObject::invokeMethod(CLogHandler::instance(), invokee, Qt::BlockingQueuedConnection);
+            QMetaObject::invokeMethod(CLogHandler::instance(), [ & ] { messageHandler(type, context, message); }, Qt::BlockingQueuedConnection);
             return;
         }
 #if defined(Q_CC_MSVC) && defined(QT_NO_DEBUG)


### PR DESCRIPTION
Don't bypass extra handling of fatal messages when
invoked in the main thread from a different thread.