### PR TITLE
Issue #178 Enable FSX checkbox for MSFS on 64-bit

### DIFF
--- a/src/blackconfig/buildconfig.inc
+++ b/src/blackconfig/buildconfig.inc
@@ -17,11 +17,6 @@
 
 namespace BlackConfig
 {
-    constexpr bool CBuildConfig::isCompiledWithMsFlightSimulatorSupport()
-    {
-        return CBuildConfig::isCompiledWithFs9Support() || CBuildConfig::isCompiledWithFsxSupport() || CBuildConfig::isCompiledWithP3DSupport();
-    }
-
     constexpr bool CBuildConfig::isCompiledWithFlightSimulatorSupport()
     {
         return CBuildConfig::isCompiledWithFsxSupport() || CBuildConfig::isCompiledWithXPlaneSupport();

--- a/src/blackconfig/buildconfig_gen.inc.in
+++ b/src/blackconfig/buildconfig_gen.inc.in
@@ -65,6 +65,15 @@ constexpr bool BlackConfig::CBuildConfig::isCompiledWithFsxSupport()
 !!ENDIF
 }
 
+constexpr bool BlackConfig::CBuildConfig::isCompiledWithMsFlightSimulatorSupport()
+{
+!!IF swiftConfig(sims.msfs)
+    return true;
+!!ELSE
+    return false;
+!!ENDIF
+}
+
 constexpr bool BlackConfig::CBuildConfig::isCompiledWithFsuipcSupport()
 {
 !!IF swiftConfig(sims.fsuipc)

--- a/src/blackgui/components/configsimulatorcomponent.cpp
+++ b/src/blackgui/components/configsimulatorcomponent.cpp
@@ -72,7 +72,8 @@ namespace BlackGui::Components
         ui->cb_FG->setChecked(fg);
 
         ui->cb_P3D->setEnabled(CBuildConfig::isCompiledWithP3DSupport());
-        ui->cb_FSX->setEnabled(CBuildConfig::isCompiledWithFsxSupport());
+        // TOOO remove MSFS check once it has its own entry
+        ui->cb_FSX->setEnabled(CBuildConfig::isCompiledWithFsxSupport() || CBuildConfig::isCompiledWithMsFlightSimulatorSupport());
         ui->cb_FS9->setEnabled(CBuildConfig::isCompiledWithFs9Support());
         ui->cb_XP->setEnabled(CBuildConfig::isCompiledWithXPlaneSupport());
         ui->cb_FG->setEnabled(CBuildConfig::isCompiledWithFGSupport());


### PR DESCRIPTION
The FSX checkbox in the config wizard only checked for the `fsx` plugin, while the checkbox is also used for MSFS. FSX proper isn’t 64-bit so this previously prevented the checkbox to ever be enabled on 64-bit. This PR enables the FSX checkbox if support for *either* is enabled in the build configuration.

Additionally, the function that checked for MSFS support in the build didn’t actually check for the `msfs` plugin but rather any of the other plugins using `fsxcommon`. This PR modifies the logic to check for the `msfs` plugin itself. I did this in a separate commit so it doesn’t have to be pulled in too if there are any problems with it.

I still need to do some testing to make sure this hasn’t broken anything else, particularly the `CBuildConfig` change.