### PR TITLE
Fix parsing of bootstrap.json and add status bar to splashscreen 

### DIFF
--- a/resources/share/shared/bootstrap/bootstrap.json
+++ b/resources/share/shared/bootstrap/bootstrap.json
@@ -71,5 +71,5 @@
             }
         ]
     },
-    "wasLoadedFromFile": false,
+    "wasLoadedFromFile": false
 }

--- a/src/blackcore/data/globalsetup.cpp
+++ b/src/blackcore/data/globalsetup.cpp
@@ -47,7 +47,7 @@ namespace BlackCore::Data
         m_vatsimStatusFileUrls = CUrlList { "https://status.vatsim.net" };
         m_vatsimDataFileUrls = CUrlList { "https://data.vatsim.net/v3/vatsim-data.json" };
         m_vatsimServerFileUrl = CUrl("https://data.vatsim.net/v3/vatsim-servers.json");
-        m_vatsimFsdHttpUrl = CUrl("http://fsd-http.connect.vatsim.net");
+        m_vatsimFsdHttpUrl = CUrl("http://fsd.vatsim.net");
         m_sharedUrls = CUrlList {
             "http://download.swift-project.org/shared/",
         };

--- a/src/blackgui/guiapplication.cpp
+++ b/src/blackgui/guiapplication.cpp
@@ -225,11 +225,11 @@ namespace BlackGui
         splashFont.setFamily("Arial");
         // splashFont.setBold(true);
         splashFont.setPointSize(10);
-        splashFont.setStretch(125);
+        splashFont.setStretch(100);
 
         m_splashScreen.reset(new CSplashScreen(pixmap.scaled(256, 256)));
         m_splashScreen->show();
-        m_splashScreen->showStatusMessage(CBuildConfig::getVersionString());
+        m_splashScreen->showStatusMessage("Version " + CBuildConfig::getVersionString());
         m_splashScreen->setSplashFont(splashFont);
 
         this->processEventsToRefreshGui();

--- a/src/blackgui/splashscreen.cpp
+++ b/src/blackgui/splashscreen.cpp
@@ -3,35 +3,38 @@
 
 #include "splashscreen.h"
 
+#include <QtMath>
+
 using namespace BlackMisc;
 
 namespace BlackGui
 {
-    CSplashScreen::CSplashScreen(const QPixmap &pixmap) : QSplashScreen(pixmap)
+    CSplashScreen::CSplashScreen(const QPixmap &pixmap)
     {
-        const int heightTe = 60;
-        const int height = pixmap.height();
-        const int width = qRound(0.9 * pixmap.width());
-        const int yPos = (height - heightTe) / 2;
-        const int xPos = (pixmap.width() - width) / 2;
+        const int height = qFloor(pixmap.height() * 1.2);
+        const int width = pixmap.width();
+        QPixmap splash(pixmap.width(), height);
+        splash.fill(Qt::transparent);
 
-        m_label = new QLabel(this);
-        m_label->setGeometry(xPos, yPos, width, 80);
-        m_label->setAlignment(Qt::AlignCenter);
-        m_label->setStyleSheet("background: rgba(0,0,0,0); color: white;");
-        m_label->setWordWrap(true);
-        m_label->setVisible(false);
+        QPainter painter(&splash);
+        painter.drawPixmap(0, 0, pixmap);
 
-        m_hideTextTimer.setSingleShot(true);
-        connect(&m_hideTextTimer, &QTimer::timeout, this, &CSplashScreen::hideText);
+        const int statusbar_height = qFloor((height - pixmap.height()) / 2.0);
+        QPixmap statusbar(width, statusbar_height);
+        statusbar.fill(QColor(200, 200, 200));
+        painter.drawPixmap(0, height - statusbar_height, statusbar);
+
+        this->setPixmap(splash);
+
+        m_clearTextTimer.setSingleShot(true);
+        connect(&m_clearTextTimer, &QTimer::timeout, this, &CSplashScreen::clearMessage);
     }
 
     void CSplashScreen::showStatusMessage(const QString &html)
     {
         if (html.isEmpty()) { return; }
-        m_label->setVisible(true);
-        m_label->setText(html);
-        m_hideTextTimer.start(2000);
+        this->showMessage(html, Qt::AlignHCenter | Qt::AlignBottom);
+        m_clearTextTimer.start(2000);
     }
 
     void CSplashScreen::showStatusMessage(const BlackMisc::CStatusMessage &message)
@@ -42,11 +45,5 @@ namespace BlackGui
     void CSplashScreen::setSplashFont(const QFont &font)
     {
         this->setFont(font);
-        m_label->setFont(font);
     }
-
-    void CSplashScreen::hideText()
-    {
-        m_label->setVisible(false);
-    };
 }

--- a/src/blackgui/splashscreen.h
+++ b/src/blackgui/splashscreen.h
@@ -35,12 +35,8 @@ namespace BlackGui
         void setSplashFont(const QFont &font);
 
     private:
-        //! Hide text
-        void hideText();
-
         QString m_message;
-        QTimer m_hideTextTimer;
-        QLabel *m_label = nullptr;
+        QTimer m_clearTextTimer;
     };
 } // ns
 

--- a/src/blackmisc/json.cpp
+++ b/src/blackmisc/json.cpp
@@ -411,7 +411,14 @@ namespace BlackMisc::Json
     QJsonObject jsonObjectFromString(const QString &json, bool acceptCacheFormat)
     {
         if (json.isEmpty()) { return QJsonObject(); }
-        const QJsonDocument jsonDoc(QJsonDocument::fromJson(json.toUtf8()));
+
+        QJsonParseError error {};
+        const QJsonDocument jsonDoc(QJsonDocument::fromJson(json.toUtf8(), &error));
+        if (error.error != QJsonParseError::NoError)
+        {
+            throw CJsonException(error.errorString());
+        }
+
         return acceptCacheFormat ? Json::unwrapCache(jsonDoc.object()) : jsonDoc.object();
     }
 


### PR DESCRIPTION
With this PR:
- A separate status bar on the splashscreen is used to print the version number instead of printing it into the logo.
- A ``CJsonException`` is thrown when  JSON parsing fails.
- Fix broken ``bootstrap.json``.
- Update the hardcoded/default VATSIM FSD HTTP endpoint (already done for the ``bootstrap.json`` with a8c487ac6eaaa6c377586ec78cfbec0775ac2aa0).

The old endpoint still seems to work (sometimes?). It seems to be used in all current swift versions because loading of the ``bootstrap.json`` with the new endpoint failed silently. This *may* be related to #203.
