### PR TITLE
Add slider to change radar tag font size

### DIFF
--- a/src/blackgui/components/radarcomponent.cpp
+++ b/src/blackgui/components/radarcomponent.cpp
@@ -22,7 +22,7 @@ using namespace BlackGui::Views;
 namespace BlackGui::Components
 {
     CRadarComponent::CRadarComponent(QWidget *parent) : QFrame(parent),
-                                                        ui(new Ui::CRadarComponent)
+                                                        ui(new Ui::CRadarComponent), m_tagFont(QApplication::font())
     {
         ui->setupUi(this);
 
@@ -39,6 +39,8 @@ namespace BlackGui::Components
         }
 
         ui->cb_RadarRange->setCurrentText(QString::number(m_rangeNM) % u" nm");
+        ui->sb_FontSize->setRange(1, 100);
+        ui->sb_FontSize->setValue(QApplication::font().pointSize());
 
         connect(ui->gv_RadarView, &CRadarView::radarViewResized, this, &CRadarComponent::fitInView);
         connect(ui->gv_RadarView, &CRadarView::zoomEvent, this, &CRadarComponent::changeRangeInSteps);
@@ -46,6 +48,7 @@ namespace BlackGui::Components
         connect(&m_headingTimer, &QTimer::timeout, this, &CRadarComponent::rotateView);
 
         connect(ui->cb_RadarRange, qOverload<int>(&QComboBox::currentIndexChanged), this, &CRadarComponent::changeRangeFromUserSelection);
+        connect(ui->sb_FontSize, qOverload<int>(&QSpinBox::valueChanged), this, &CRadarComponent::updateFont);
         connect(ui->cb_Callsign, &QCheckBox::toggled, this, &CRadarComponent::refreshTargets);
         connect(ui->cb_Heading, &QCheckBox::toggled, this, &CRadarComponent::refreshTargets);
         connect(ui->cb_Altitude, &QCheckBox::toggled, this, &CRadarComponent::refreshTargets);
@@ -175,6 +178,7 @@ namespace BlackGui::Components
                     }
 
                     tag->setPlainText(tagText);
+                    tag->setFont(m_tagFont);
                     tag->setPos(position);
                     tag->setDefaultTextColor(Qt::green);
                     tag->setFlags(QGraphicsItem::ItemIgnoresTransformations);
@@ -257,6 +261,12 @@ namespace BlackGui::Components
             m_rangeNM = range;
             fitInView();
         }
+    }
+
+    void CRadarComponent::updateFont(int pointSize)
+    {
+        m_tagFont.setPointSize(pointSize);
+        this->refreshTargets();
     }
 
     void CRadarComponent::onInfoAreaTabBarChanged(int index)

--- a/src/blackgui/components/radarcomponent.h
+++ b/src/blackgui/components/radarcomponent.h
@@ -54,6 +54,7 @@ namespace BlackGui::Components
         void fitInView();
         void changeRangeInSteps(bool zoomIn);
         void changeRangeFromUserSelection(int index);
+        void updateFont(int pointSize);
 
         static QPointF polarPoint(double distance, double angleRadians);
 
@@ -73,6 +74,8 @@ namespace BlackGui::Components
         int m_rotatenAngle = 0;
         QTimer m_updateTimer;
         QTimer m_headingTimer;
+
+        QFont m_tagFont;
 
         BlackCore::CActionBind m_actionZoomIn { BlackMisc::Input::radarZoomInHotkeyAction(), BlackMisc::Input::radarZoomInHotkeyIcon(), this, &CRadarComponent::rangeZoomIn };
         BlackCore::CActionBind m_actionZoomOut { BlackMisc::Input::radarZoomOutHotkeyAction(), BlackMisc::Input::radarZoomOutHotkeyIcon(), this, &CRadarComponent::rangeZoomOut };

--- a/src/blackgui/components/radarcomponent.ui
+++ b/src/blackgui/components/radarcomponent.ui
@@ -44,10 +44,16 @@
       <property name="bottomMargin">
        <number>2</number>
       </property>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="cb_LockNorth">
+      <item row="0" column="4">
+       <widget class="QSpinBox" name="sb_FontSize"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="cb_Callsign">
         <property name="text">
-         <string>Lock North</string>
+         <string>Callsign</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -61,7 +67,17 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2" colspan="2">
+      <item row="0" column="3">
+       <widget class="QLabel" name="lbl_FontSize">
+        <property name="text">
+         <string>Font size</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
        <widget class="QCheckBox" name="cb_Altitude">
         <property name="text">
          <string>Altitude (FL)</string>
@@ -71,20 +87,17 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cb_LockNorth">
+        <property name="text">
+         <string>Lock North</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QCheckBox" name="cb_GroundSpeed">
         <property name="text">
          <string>GroundSpeed</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="cb_Callsign">
-        <property name="text">
-         <string>Callsign</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -101,10 +114,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QComboBox" name="cb_RadarRange"/>
-      </item>
-      <item row="2" column="0" colspan="2">
+      <item row="1" column="3">
        <widget class="QLabel" name="lbl_Range">
         <property name="text">
          <string>Range</string>
@@ -113,6 +123,9 @@
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QComboBox" name="cb_RadarRange"/>
       </item>
      </layout>
     </widget>
@@ -131,6 +144,7 @@
   <tabstop>cb_Callsign</tabstop>
   <tabstop>cb_Heading</tabstop>
   <tabstop>cb_Altitude</tabstop>
+  <tabstop>sb_FontSize</tabstop>
   <tabstop>cb_LockNorth</tabstop>
   <tabstop>cb_GroundSpeed</tabstop>
   <tabstop>cb_Grid</tabstop>

--- a/src/blackgui/components/radarcomponent.ui
+++ b/src/blackgui/components/radarcomponent.ui
@@ -97,7 +97,7 @@
       <item row="1" column="1">
        <widget class="QCheckBox" name="cb_GroundSpeed">
         <property name="text">
-         <string>GroundSpeed</string>
+         <string>Ground speed</string>
         </property>
         <property name="checked">
          <bool>true</bool>


### PR DESCRIPTION
This setting is currently not persistent and is by default set to the font size of swiftgui. But I assume changing the font size is more a spontaneous action, for example in busy airspace, so this should be fine.

Fixes #121 