### PR TITLE
Build MacOS executables as application bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(SWIFT_USE_CRASHPAD)
 endif()
 
 if(APPLE)
-    set(CMAKE_INSTALL_RPATH @loader_path/../lib)
+    set(CMAKE_INSTALL_RPATH @loader_path/../../../../lib)
 elseif(UNIX)
     set(CMAKE_INSTALL_RPATH \$ORIGIN/../lib)
 endif()

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -27,7 +27,7 @@ elseif(SWIFT_WIN64)
 elseif(APPLE)
     set(crashpad_handler_path ${swift_SOURCE_DIR}/externals/macx-clang/64/bin/swift_crashpad_handler)
 endif()
-install(FILES ${crashpad_handler_path} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(PROGRAMS ${crashpad_handler_path} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 # create_dbus_machineid
 if(APPLE)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -384,11 +384,14 @@ class MacOSBuilder(Builder):
         return True
 
     def _strip_debug(self):
+        bundle_files = [
+            "bin/swiftcore.app/Contents/MacOS/swiftcore",
+            "bin/swiftdata.app/Contents/MacOS/swiftdata",
+            "bin/swiftguistd.app/Contents/MacOS/swiftguistd",
+            "bin/swiftlauncher.app/Contents/MacOS/swiftlauncher",
+        ]
+
         files = [
-            "bin/swiftcore",
-            "bin/swiftdata",
-            "bin/swiftguistd",
-            "bin/swiftlauncher",
             "lib/libcore.dylib",
             "lib/libgui.dylib",
             "lib/libinput.dylib",
@@ -405,6 +408,11 @@ class MacOSBuilder(Builder):
             "xswiftbus/64/mac.xpl",
         ]
         dist_path = path.join(self._get_swift_source_path(), "dist")
+
+        # Put output of bundle files directly in bin folder
+        for file in bundle_files:
+            subprocess.check_call(["dsymutil", path.join(dist_path, file), "-o", path.join(dist_path, "bin", file.split("/")[-1] + ".dSYM")], env=dict(os.environ))
+
         for file in files:
             subprocess.check_call(["dsymutil", path.join(dist_path, file)], env=dict(os.environ))
 

--- a/src/swiftcore/CMakeLists.txt
+++ b/src/swiftcore/CMakeLists.txt
@@ -22,10 +22,22 @@ target_link_libraries(swiftcore
         core
         )
 
+if(APPLE)
+    set_target_properties(swiftcore PROPERTIES MACOSX_BUNDLE TRUE)
+    set_target_properties(swiftcore PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+    set(RESOURCE_FILES swiftcore.icns qt.conf)
+    target_sources(swiftcore PRIVATE ${RESOURCE_FILES})
+    set_target_properties(swiftcore PROPERTIES RESOURCE "${RESOURCE_FILES}")
+endif()
+
 add_dependencies(swiftcore resources)
 
 if(WIN32)
         add_dependencies(swiftcore copy_externals_to_build_dir)
 endif()
 
-install(TARGETS swiftcore)
+if(APPLE)
+    install(TARGETS swiftcore BUNDLE DESTINATION bin)
+else()
+    install(TARGETS swiftcore)
+endif()

--- a/src/swiftcore/Info.plist
+++ b/src/swiftcore/Info.plist
@@ -7,19 +7,19 @@
 	<key>CFBundleDisplayName</key>
 	<string>swift core</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>swiftcore</string>
 	<key>CFBundleGetInfoString</key>
 	<string>swift project - free and open source pilot client</string>
 	<key>CFBundleIconFile</key>
-	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<string>swiftcore.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>org.swift-project.swiftcore</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
+	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>10.13</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/swiftcore/Info.plist
+++ b/src/swiftcore/Info.plist
@@ -25,6 +25,6 @@
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>This application needs access to your Microphone for Vatsim Voice.</string>
+	<string>This application needs access to your Microphone for VATSIM Voice.</string>
 </dict>
 </plist>

--- a/src/swiftdata/CMakeLists.txt
+++ b/src/swiftdata/CMakeLists.txt
@@ -23,10 +23,22 @@ target_link_libraries(swiftdata
         core
         )
 
+if(APPLE)
+    set_target_properties(swiftdata PROPERTIES MACOSX_BUNDLE TRUE)
+    set_target_properties(swiftdata PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+    set(RESOURCE_FILES swiftdata.icns qt.conf)
+    target_sources(swiftdata PRIVATE ${RESOURCE_FILES})
+    set_target_properties(swiftdata PROPERTIES RESOURCE "${RESOURCE_FILES}")
+endif()
+
 add_dependencies(swiftdata resources)
 
 if(WIN32)
         add_dependencies(swiftdata copy_externals_to_build_dir)
 endif()
 
-install(TARGETS swiftdata)
+if(APPLE)
+    install(TARGETS swiftdata BUNDLE DESTINATION bin)
+else()
+    install(TARGETS swiftdata)
+endif()

--- a/src/swiftdata/Info.plist
+++ b/src/swiftdata/Info.plist
@@ -7,19 +7,19 @@
 	<key>CFBundleDisplayName</key>
 	<string>swift data</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>swiftdata</string>
 	<key>CFBundleGetInfoString</key>
 	<string>swift project - free and open source pilot client</string>
 	<key>CFBundleIconFile</key>
-	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<string>swiftdata.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>org.swift-project.swiftdata</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
+	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>10.13</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/swiftguistandard/CMakeLists.txt
+++ b/src/swiftguistandard/CMakeLists.txt
@@ -28,10 +28,22 @@ target_link_libraries(swiftguistd
         sound
         )
 
+if(APPLE)
+    set_target_properties(swiftguistd PROPERTIES MACOSX_BUNDLE TRUE)
+    set_target_properties(swiftguistd PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+    set(RESOURCE_FILES swift.icns qt.conf)
+    target_sources(swiftguistd PRIVATE ${RESOURCE_FILES})
+    set_target_properties(swiftguistd PROPERTIES RESOURCE "${RESOURCE_FILES}")
+endif()
+
 add_dependencies(swiftguistd resources)
 
 if(WIN32)
         add_dependencies(swiftguistd copy_externals_to_build_dir)
 endif()
 
-install(TARGETS swiftguistd)
+if(APPLE)
+    install(TARGETS swiftguistd BUNDLE DESTINATION bin)
+else()
+    install(TARGETS swiftguistd)
+endif()

--- a/src/swiftguistandard/Info.plist
+++ b/src/swiftguistandard/Info.plist
@@ -7,19 +7,19 @@
 	<key>CFBundleDisplayName</key>
 	<string>swift gui</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>swiftguistd</string>
 	<key>CFBundleGetInfoString</key>
 	<string>swift project - free and open source pilot client</string>
 	<key>CFBundleIconFile</key>
-	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<string>swift.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>org.swift-project.swiftguistd</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
+	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>10.13</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/swiftguistandard/Info.plist
+++ b/src/swiftguistandard/Info.plist
@@ -25,6 +25,6 @@
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>This application needs access to your Microphone for Vatsim Voice.</string>
+	<string>This application needs access to your Microphone for VATSIM Voice.</string>
 </dict>
 </plist>

--- a/src/swiftlauncher/CMakeLists.txt
+++ b/src/swiftlauncher/CMakeLists.txt
@@ -23,10 +23,22 @@ target_link_libraries(swiftlauncher
         core
         )
 
+if(APPLE)
+    set_target_properties(swiftlauncher PROPERTIES MACOSX_BUNDLE TRUE)
+    set_target_properties(swiftlauncher PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+    set(RESOURCE_FILES swiftlauncher.icns qt.conf)
+    target_sources(swiftlauncher PRIVATE ${RESOURCE_FILES})
+    set_target_properties(swiftlauncher PROPERTIES RESOURCE "${RESOURCE_FILES}")
+endif()
+
 add_dependencies(swiftlauncher resources)
 
 if(WIN32)
         add_dependencies(swiftlauncher copy_externals_to_build_dir)
 endif()
 
-install(TARGETS swiftlauncher)
+if(APPLE)
+    install(TARGETS swiftlauncher BUNDLE DESTINATION bin)
+else()
+    install(TARGETS swiftlauncher)
+endif()

--- a/src/swiftlauncher/Info.plist
+++ b/src/swiftlauncher/Info.plist
@@ -25,6 +25,6 @@
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
         <key>NSMicrophoneUsageDescription</key>
-        <string>This application needs access to your Microphone for Vatsim Voice.</string>
+        <string>This application needs access to your Microphone for VATSIM Voice.</string>
 </dict>
 </plist>

--- a/src/swiftlauncher/Info.plist
+++ b/src/swiftlauncher/Info.plist
@@ -7,19 +7,19 @@
 	<key>CFBundleDisplayName</key>
 	<string>swift launcher</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>swiftlauncher</string>
 	<key>CFBundleGetInfoString</key>
 	<string>swift project - free and open source pilot client</string>
 	<key>CFBundleIconFile</key>
-	<string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+	<string>swiftlauncher.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>org.swift-project.swiftlauncher</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
+	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>10.13</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
With application bundles, the executables are directly executed as GUI application (without terminal) and contain metadata like the icon file or the possibility to request microphone permission.

For now, I hardcoded all values in the ``Info.plist`` files. In the future we can might utilize the automatic generation with CMake [1]. But this requires a non-default template because this does not support ``NSMicrophoneUsageDescription`` and other keys out of the box.

[1] https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE_INFO_PLIST.html