### PR TITLE
Show warning if Input Monitoring is not allowed

### DIFF
--- a/src/blackinput/macos/macosinpututils.h
+++ b/src/blackinput/macos/macosinpututils.h
@@ -16,6 +16,9 @@ namespace BlackInput
     public:
         CMacOSInputUtils() = delete;
 
+        //! Check OS permission for input monitoring access
+        static bool hasAccess();
+
         //! Request OS permission for input monitoring access
         static bool requestAccess();
 

--- a/src/blackinput/macos/macosinpututils.mm
+++ b/src/blackinput/macos/macosinpututils.mm
@@ -8,6 +8,19 @@
 
 namespace BlackInput
 {
+
+    bool CMacOSInputUtils::hasAccess()
+    {
+        if (@available(macOS 10.15, *))
+        {
+            return IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == IOHIDAccessType::kIOHIDAccessTypeGranted;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
     bool CMacOSInputUtils::requestAccess()
     {
         if (@available(macOS 10.15, *))

--- a/src/swiftguistandard/CMakeLists.txt
+++ b/src/swiftguistandard/CMakeLists.txt
@@ -29,6 +29,8 @@ target_link_libraries(swiftguistd
         )
 
 if(APPLE)
+    target_link_libraries(swiftguistd PUBLIC input)
+
     set_target_properties(swiftguistd PROPERTIES MACOSX_BUNDLE TRUE)
     set_target_properties(swiftguistd PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
     set(RESOURCE_FILES swift.icns qt.conf)

--- a/src/swiftguistandard/swiftguistd.cpp
+++ b/src/swiftguistandard/swiftguistd.cpp
@@ -28,6 +28,10 @@
 #include "blackmisc/threadutils.h"
 #include "blackconfig/buildconfig.h"
 
+#if defined(Q_OS_MACOS)
+#    include "blackinput/macos/macosinpututils.h"
+#endif
+
 #include "swiftguistd.h"
 #include <QAction>
 #include <QDateTime>
@@ -474,6 +478,16 @@ void SwiftGuiStd::verifyPrerequisites()
     {
         msgs.push_back(sGui->getIContextSimulator()->verifyPrerequisites());
     }
+
+#if defined(Q_OS_MACOS)
+    if (!BlackInput::CMacOSInputUtils::hasAccess())
+    {
+        // A log message about missing permissions is already emitted when initializing the keyboard.
+        // But this happens way before initializing the GUI. Hence do the check here again to show an error message
+        // to the user
+        msgs.push_back(CLogMessage(this).error(u"Cannot access the keyboard. Is \"Input Monitoring\" for swift enabled?"));
+    }
+#endif
 
     if (msgs.hasWarningOrErrorMessages())
     {


### PR DESCRIPTION
Related to #125

With this PR, an additional error message is logged/shown if the Input Monitoring permission is not granted on macOS. A message about this is already emitted when requesting the permission, but this happens before the UI is initialized and will therefore not be displayed to the user (except in the terminal and log file).

@oktal3700 Any idea on how we could avoid logging this twice? The keyboard initialization happens in the ``CInputManager`` which again is initialized by ``CApplication`` which AFAIK should be UI independent. In the future maybe some mechanism should be added to show error messages in the early initialization phase.