### PR TITLE
Support ICAO equipment codes in flightplans

### DIFF
--- a/resources/share/shared/bootstrap/bootstrap.json
+++ b/resources/share/shared/bootstrap/bootstrap.json
@@ -66,5 +66,11 @@
             }
         ]
     },
+    "comNavEquipmentHelpUrl": {
+        "url": "https://en.wikipedia.org/wiki/Equipment_codes#Radio_communication,_navigation_and_approach_aid_equipment_and_capabilities"
+    },
+    "ssrEquipmentHelpUrl": {
+        "url": "https://en.wikipedia.org/wiki/Equipment_codes#Surveillance_equipment_codes"
+    },
     "wasLoadedFromFile": false
 }

--- a/samples/blackmisc/samplesperformance.cpp
+++ b/samples/blackmisc/samplesperformance.cpp
@@ -704,7 +704,7 @@ namespace BlackSample
         CDistributorList distributors;
         for (int i = 0; i < numberOfMemoParts; ++i)
         {
-            aircraftIcaos.push_back(CAircraftIcaoCode("A" + QString::number(i), "A" + QString::number(i), "L1P", "Lego", "Foo", "M", false, false, false, 0));
+            aircraftIcaos.push_back(CAircraftIcaoCode("A" + QString::number(i), "A" + QString::number(i), "L1P", "Lego", "Foo", CWakeTurbulenceCategory::MEDIUM, false, false, false, 0));
             liveries.push_back(CLivery("A" + QString::number(i), CAirlineIcaoCode("A" + QString::number(i), "Foo", CCountry("DE", "Germany"), "Foo", false, false), "Foo", "red", "blue", false));
             distributors.push_back(CDistributor(QString::number(i), "Foo", {}, {}, CSimulatorInfo::FSX));
         }

--- a/src/blackcore/context/contextnetworkimpl.cpp
+++ b/src/blackcore/context/contextnetworkimpl.cpp
@@ -283,7 +283,7 @@ namespace BlackCore::Context
         }
 
         m_fsdClient->setClientIdAndKey(static_cast<quint16>(clientId), clientKey.toLocal8Bit());
-        m_fsdClient->setClientCapabilities(Capabilities::AircraftInfo | Capabilities::FastPos | Capabilities::VisPos | Capabilities::AtcInfo | Capabilities::AircraftConfig);
+        m_fsdClient->setClientCapabilities(Capabilities::AircraftInfo | Capabilities::FastPos | Capabilities::VisPos | Capabilities::AtcInfo | Capabilities::AircraftConfig | Capabilities::IcaoEquipment);
         m_fsdClient->setServer(server);
 
         m_fsdClient->setPilotRating(PilotRating::Student);

--- a/src/blackcore/context/contextownaircraft.cpp
+++ b/src/blackcore/context/contextownaircraft.cpp
@@ -48,7 +48,7 @@ namespace BlackCore::Context
         // if all fails
         static const CAircraftModel defaultModel(
             "", CAircraftModel::TypeOwnSimulatorModel, "default model",
-            CAircraftIcaoCode("C172", "L1P", "Cessna", "172", "L", true, false, false, 0));
+            CAircraftIcaoCode("C172", "L1P", "Cessna", "172", CWakeTurbulenceCategory::LIGHT, true, false, false, 0));
 
         // create one from DB data
         if (sApp && sApp->hasWebDataServices())

--- a/src/blackcore/data/globalsetup.cpp
+++ b/src/blackcore/data/globalsetup.cpp
@@ -245,8 +245,7 @@ namespace BlackCore::Data
     CServerList CGlobalSetup::getPredefinedServersPlusHardcodedServers() const
     {
         static const CServerList hardcoded(
-            { CServer::swiftFsdTestServer(),
-              CServer::fscFsdServer(),
+            { CServer::fscFsdServer(),
               CServer::esTowerView() });
         CServerList testServers(m_predefinedServers);
         testServers.addIfAddressNotExists(hardcoded);

--- a/src/blackcore/data/globalsetup.h
+++ b/src/blackcore/data/globalsetup.h
@@ -208,6 +208,12 @@ namespace BlackCore::Data
         //! NCEP GFS Forecasts (0.25 degree grid) data url
         BlackMisc::Network::CUrl getNcepGlobalForecastSystemUrl25() const { return m_ncepGlobalForecastSystemUrl25; }
 
+        //! COM/NAV equipment code help URL
+        BlackMisc::Network::CUrl getComNavEquipmentHelpUrl() const { return m_comNavEquipmentHelpUrl; }
+
+        //! SSR equipment code help URL
+        BlackMisc::Network::CUrl getSsrEquipmentHelpUrl() const { return m_ssrEquipmentHelpUrl; }
+
         //! \copydoc BlackMisc::Mixin::String::toQString
         QString convertToQString(bool i18n = false) const;
 
@@ -252,6 +258,8 @@ namespace BlackCore::Data
         BlackMisc::Network::CServerList m_predefinedServers; //!< Predefined servers loaded from setup file
         BlackMisc::Network::CUrl m_ncepGlobalForecastSystemUrl; //!< NCEP GFS url 0.5 degree resolution
         BlackMisc::Network::CUrl m_ncepGlobalForecastSystemUrl25; //!< NCEP GFS url 0.25 degree resolution
+        BlackMisc::Network::CUrl m_comNavEquipmentHelpUrl; //!< Help URL for COM/NAV equipment codes
+        BlackMisc::Network::CUrl m_ssrEquipmentHelpUrl; //!< Help URL for SSR equipment codes
 
         // transient members, to be switched on/off via GUI or set from reader
         bool m_dbDebugFlag = false; //!< can trigger DEBUG on the server, so you need to know what you are doing
@@ -281,6 +289,8 @@ namespace BlackCore::Data
             BLACK_METAMEMBER(mappingMinimumVersion),
             BLACK_METAMEMBER(ncepGlobalForecastSystemUrl),
             BLACK_METAMEMBER(ncepGlobalForecastSystemUrl25),
+            BLACK_METAMEMBER(comNavEquipmentHelpUrl),
+            BLACK_METAMEMBER(ssrEquipmentHelpUrl),
             BLACK_METAMEMBER(dbDebugFlag, BlackMisc::DisabledForJson)
         );
     };

--- a/src/blackcore/fsd/enums.h
+++ b/src/blackcore/fsd/enums.h
@@ -168,7 +168,10 @@ namespace BlackCore::Fsd
         Stealth = (1 << 8),
 
         /*! Aircraft Config */
-        AircraftConfig = (1 << 9)
+        AircraftConfig = (1 << 9),
+
+        /*! Process aircraft ICAO in flightplan as ICAO equipment code (e.g. B737/M-SDE2E3FGHIRWXY/LB1) */
+        IcaoEquipment = (1 << 10)
     };
 
     //! @{

--- a/src/blackcore/fsd/flightplan.h
+++ b/src/blackcore/fsd/flightplan.h
@@ -33,7 +33,7 @@ namespace BlackCore::Fsd
         //! @{
         //! Properties
         FlightType m_flightType {};
-        QString m_aircraftIcaoType;
+        QString m_aircraftIcaoType; //!< Contains the full equipment string in FAA or ICAO format, depending on the server
         int m_trueCruisingSpeed = 0;
         QString m_depAirport;
         int m_estimatedDepTime = 0;

--- a/src/blackcore/fsd/serializer.cpp
+++ b/src/blackcore/fsd/serializer.cpp
@@ -453,6 +453,7 @@ namespace BlackCore::Fsd
         case Capabilities::FastPos: return "FASTPOS";
         case Capabilities::Stealth: return "STEALTH";
         case Capabilities::AircraftConfig: return "ACCONFIG";
+        case Capabilities::IcaoEquipment: return "ICAOEQ";
         }
 
         return {};
@@ -479,6 +480,8 @@ namespace BlackCore::Fsd
             return Capabilities::Stealth;
         else if (str == "ACCONFIG")
             return Capabilities::AircraftConfig;
+        else if (str == "ICAOEQ")
+            return Capabilities::IcaoEquipment;
 
         return Capabilities::None;
     }

--- a/src/blackcore/vatsim/vatsimdatafilereader.cpp
+++ b/src/blackcore/vatsim/vatsimdatafilereader.cpp
@@ -305,11 +305,11 @@ namespace BlackCore::Vatsim
         const CSpeed groundspeed(pilot["groundspeed"].toInt(), CSpeedUnit::kts());
         const CAircraftSituation situation(callsign, position, heading, {}, {}, groundspeed);
         CSimulatedAircraft aircraft(callsign, user, situation);
-        const QString icaoAndEquipment(pilot["flight_plan"]["aircraft"].toString().trimmed());
-        const QString icao(CFlightPlan::aircraftIcaoCodeFromEquipmentCode(icaoAndEquipment));
-        if (CAircraftIcaoCode::isValidDesignator(icao))
+        const QString icaoAndEquipment(pilot["flight_plan"]["aircraft"].toString().trimmed()); // in ICAO format
+        CFlightPlanAircraftInfo info(icaoAndEquipment);
+        if (info.getAircraftIcao().hasValidDesignator())
         {
-            aircraft.setAircraftIcaoCode(icao);
+            aircraft.setAircraftIcaoCode(info.getAircraftIcao());
         }
         else if (!icaoAndEquipment.isEmpty())
         {

--- a/src/blackgui/components/flightplancomponent.cpp
+++ b/src/blackgui/components/flightplancomponent.cpp
@@ -1023,6 +1023,11 @@ namespace BlackGui::Components
             else
             {
                 CFlightPlan fp = CFlightPlan::fromSimBriefFormat(simBriefFP);
+
+                // Voice capability is not included from SimBrief -> set capability from UI
+                const QString currentVoiceCapability = ui->cb_VoiceCapabilities->currentText();
+                fp.setVoiceCapabilities(CFlightPlanRemarks::textToVoiceCapabilitiesRemarks(currentVoiceCapability));
+
                 this->fillWithFlightPlanData(fp);
             }
         } // no error

--- a/src/blackgui/components/flightplancomponent.cpp
+++ b/src/blackgui/components/flightplancomponent.cpp
@@ -225,7 +225,7 @@ namespace BlackGui::Components
 
         if (aircraft.getAircraftIcaoCode().isLoadedFromDb() && aircraft.getAircraftIcaoCode().hasValidWtc())
         {
-            const QString wtc = aircraft.getAircraftIcaoCode().getWtc().toUpper();
+            const QString wtc = toSingleLetterCode(aircraft.getAircraftIcaoCode().getWtc());
             const bool heavyFlag = (wtc.startsWith("H", Qt::CaseInsensitive) || wtc.startsWith("S", Qt::CaseInsensitive));
             ui->cb_Heavy->setChecked(heavyFlag);
         }
@@ -825,7 +825,7 @@ namespace BlackGui::Components
         QPointer<CFlightPlanComponent> myself(this);
         QTimer::singleShot(25, this, [=] {
             if (!myself || !sGui || sGui->isShuttingDown()) { return; }
-            const bool heavy = icao.getWtc().startsWith("H");
+            const bool heavy = icao.getWtc() == BlackMisc::Aviation::WakeTurbulenceCategory::HEAVY;
             ui->cb_Heavy->setChecked(heavy);
             if (heavy) { ui->cb_Tcas->setChecked(false); }
             this->buildPrefixIcaoSuffix();

--- a/src/blackgui/components/flightplancomponent.cpp
+++ b/src/blackgui/components/flightplancomponent.cpp
@@ -136,7 +136,6 @@ namespace BlackGui::Components
         connect(ui->cb_VoiceCapabilities, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::currentTextChangedToBuildRemarks, Qt::QueuedConnection);
         connect(ui->cb_VoiceCapabilities, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::syncVoiceComboBoxes, Qt::QueuedConnection);
         connect(ui->cb_VoiceCapabilitiesFirstPage, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::syncVoiceComboBoxes, Qt::QueuedConnection);
-        connect(ui->cb_NavigationEquipment, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::currentTextChangedToBuildRemarks, Qt::QueuedConnection);
         connect(ui->cb_PerformanceCategory, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::currentTextChangedToBuildRemarks, Qt::QueuedConnection);
         connect(ui->cb_PilotRating, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::currentTextChangedToBuildRemarks, Qt::QueuedConnection);
         connect(ui->cb_RequiredNavigationPerformance, &QComboBox::currentTextChanged, this, &CFlightPlanComponent::currentTextChangedToBuildRemarks, Qt::QueuedConnection);
@@ -737,12 +736,6 @@ namespace BlackGui::Components
         if (v.contains("10")) { rem.append("RNP10 "); }
         else if (v.contains("4")) { rem.append("RNP4 "); }
 
-        v = ui->cb_NavigationEquipment->currentText().toUpper();
-        if (v.contains("VORS")) { rem.append("NAV/VORNDB "); }
-        else if (v.contains("SIDS")) { rem.append("NAV/GPSRNAV "); }
-        if (v.contains("DEFAULT")) { rem.append("NAV/GPS "); }
-        else if (v.contains("OCEANIC")) { rem.append("NAV/GPSOCEANIC "); }
-
         v = ui->cb_PerformanceCategory->currentText().toUpper();
         if (v.startsWith("A")) { rem.append("PER/A "); }
         else if (v.startsWith("B")) { rem.append("PER/B "); }
@@ -851,8 +844,7 @@ namespace BlackGui::Components
             msgs.push_back(CStatusMessage(this).validationInfo(u"No SID/STARs"));
             ui->cb_RequiredNavigationPerformance->setCurrentIndex(0);
             ui->cb_PerformanceCategory->setCurrentIndex(0);
-            ui->cb_NavigationEquipment->setCurrentIndex(0);
-            msgs.push_back(CStatusMessage(this).validationInfo(u"Set navigation and performance to VFR"));
+            msgs.push_back(CStatusMessage(this).validationInfo(u"Set performance to VFR"));
         }
         else
         {
@@ -866,8 +858,7 @@ namespace BlackGui::Components
                     msgs.push_back(CStatusMessage(this).validationInfo(u"Jet >=2 engines"));
                     msgs.push_back(CStatusMessage(this).validationInfo(u"SID/STARs"));
                     ui->cb_NoSidsStarts->setChecked(false);
-                    ui->cb_NavigationEquipment->setCurrentText("GPS or FMC capable of SIDs/STARs");
-                    msgs.push_back(CStatusMessage(this).validationInfo(u"GPS or FMC capable of SIDs/STARs"));
+                    msgs.push_back(CStatusMessage(this).validationInfo(u"Capable of SIDs/STARs"));
 
                     // reset those values
                     ui->cb_RequiredNavigationPerformance->setCurrentIndex(0);
@@ -965,15 +956,6 @@ namespace BlackGui::Components
         {
             CGuiUtility::setComboBoxValueByContainingString(ui->cb_VoiceCapabilitiesFirstPage, "RECEIVE");
             CGuiUtility::setComboBoxValueByContainingString(ui->cb_VoiceCapabilities, "RECEIVE");
-        }
-
-        if (remarks.contains("NAV/GPSRNAV"))
-        {
-            CGuiUtility::setComboBoxValueByContainingString(ui->cb_NavigationEquipment, "GPS OR FMC");
-        }
-        else if (remarks.contains("NAV/VORNDB"))
-        {
-            CGuiUtility::setComboBoxValueByContainingString(ui->cb_NavigationEquipment, "DIRECT VOR");
         }
 
         const int selcal = remarks.indexOf("SEL/");

--- a/src/blackgui/components/flightplancomponent.ui
+++ b/src/blackgui/components/flightplancomponent.ui
@@ -86,322 +86,7 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <item row="1" column="0">
-           <widget class="QComboBox" name="cb_FlightRule">
-            <item>
-             <property name="text">
-              <string>IFR</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>VFR</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>SVFR</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>DVFR</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="7" column="3">
-           <widget class="QLineEdit" name="le_AlternateAirport">
-            <property name="maxLength">
-             <number>4</number>
-            </property>
-            <property name="placeholderText">
-             <string>ICAO, e.g. EDDF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QLineEdit" name="le_CruiseTrueAirspeed">
-            <property name="maxLength">
-             <number>40</number>
-            </property>
-            <property name="placeholderText">
-             <string>e.g. 100 kts</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QWidget" name="wi_PrefixButtons" native="true">
-            <layout class="QHBoxLayout" name="hl_PrefixButtons">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="lbl_Equipment">
-               <property name="toolTip">
-                <string>Equipment</string>
-               </property>
-               <property name="text">
-                <string>3. Eqpt.</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="hs_Buttons">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item alignment="Qt::AlignRight">
-              <widget class="QCheckBox" name="cb_Heavy">
-               <property name="toolTip">
-                <string>H/ heavy prefix</string>
-               </property>
-               <property name="text">
-                <string>Heavy</string>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignRight">
-              <widget class="QCheckBox" name="cb_Tcas">
-               <property name="toolTip">
-                <string>T/ TCAS prefix</string>
-               </property>
-               <property name="text">
-                <string>TCAS</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="QLabel" name="lbl_FuelOnBoard">
-            <property name="text">
-             <string>12. Fuel on board</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="2">
-           <widget class="QPushButton" name="pb_RemarksGenerator">
-            <property name="toolTip">
-             <string>goto generator page</string>
-            </property>
-            <property name="text">
-             <string>goto gen.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lbl_AircraftType">
-            <property name="toolTip">
-             <string>Aircraft type</string>
-            </property>
-            <property name="text">
-             <string>3. Aircraft</string>
-            </property>
-            <property name="scaledContents">
-             <bool>false</bool>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="4">
-           <widget class="QPlainTextEdit" name="pte_Route">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>75</height>
-             </size>
-            </property>
-            <property name="tabChangesFocus">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QPushButton" name="pb_Remarks">
-            <property name="text">
-             <string>11.remarks</string>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="lbl_PilotsNameAndHomeBase">
-            <property name="toolTip">
-             <string>pilot's name</string>
-            </property>
-            <property name="text">
-             <string>14. Pilot / homebase</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="3">
-           <widget class="QPushButton" name="pb_GetFromGenerator">
-            <property name="toolTip">
-             <string>copy from generator page</string>
-            </property>
-            <property name="text">
-             <string>from gen.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <layout class="QGridLayout" name="gl_EquipmentIcao">
-            <item row="0" column="4">
-             <widget class="QToolButton" name="tb_HelpEquipment">
-              <property name="toolTip">
-               <string>equipment code help</string>
-              </property>
-              <property name="whatsThis">
-               <string>equipment code help</string>
-              </property>
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../blackmisc/blackmisc.qrc">
-                <normaloff>:/pastel/icons/pastel/16/help.png</normaloff>:/pastel/icons/pastel/16/help.png</iconset>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QLineEdit" name="le_EquipmentSuffix">
-              <property name="maxLength">
-               <number>1</number>
-              </property>
-              <property name="placeholderText">
-               <string>equip.code</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbl_Type">
-            <property name="text">
-             <string>1. Type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QLineEdit" name="le_TakeOffTimePlanned">
-            <property name="inputMask">
-             <string>99:99</string>
-            </property>
-            <property name="text">
-             <string>00:00</string>
-            </property>
-            <property name="maxLength">
-             <number>5</number>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLabel" name="lbl_EstimatedTimeEnroute">
-            <property name="toolTip">
-             <string>Estimated time enroute</string>
-            </property>
-            <property name="text">
-             <string>10. Est.time enroute</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="lbl_CruiseTrueAirspeed">
-            <property name="toolTip">
-             <string>True airspeed</string>
-            </property>
-            <property name="text">
-             <string>4. TAS</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="3">
-           <widget class="QLineEdit" name="le_PilotsHomeBase">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="placeholderText">
-             <string>homebase (read only)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="1" colspan="3">
-           <widget class="QLineEdit" name="le_LastSent">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="placeholderText">
-             <string>sent time will go here (read only)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLineEdit" name="le_AircraftType">
-            <property name="placeholderText">
-             <string>ICAO, e.g. A321</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="lbl_LastSent">
-            <property name="text">
-             <string>Sent</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="lbl_OriginAirport">
-            <property name="text">
-             <string>5. Departure airport</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1" colspan="2">
-           <widget class="QLineEdit" name="le_PilotsName">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="placeholderText">
-             <string>pilot's name (read only)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0" colspan="4">
+          <item row="10" column="0" colspan="4">
            <widget class="QPlainTextEdit" name="pte_Remarks">
             <property name="maximumSize">
              <size>
@@ -417,17 +102,116 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
-           <widget class="QLabel" name="lbl_AlternateAirport">
+          <item row="1" column="3">
+           <widget class="QComboBox" name="cb_Wtc"/>
+          </item>
+          <item row="3" column="0">
+           <layout class="QGridLayout" name="gl_NavComEquipment">
+            <item row="0" column="4">
+             <widget class="QToolButton" name="tb_EditNavComEquipment">
+              <property name="toolTip">
+               <string>Edit</string>
+              </property>
+              <property name="whatsThis">
+               <string>Edit Nav/Com equipment code</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../blackmisc/blackmisc.qrc">
+                <normaloff>:/pastel/icons/pastel/16/pencil.png</normaloff>:/pastel/icons/pastel/16/pencil.png</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLineEdit" name="le_NavComEquipment">
+              <property name="placeholderText">
+               <string>equip.code</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="9" column="1">
+           <widget class="QComboBox" name="cb_VoiceCapabilitiesFirstPage">
+            <item>
+             <property name="text">
+              <string>Full voice</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Text only</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Receive voice</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="lbl_Callsign">
             <property name="text">
-             <string>13. Alternate airport</string>
+             <string>2. Callsign</string>
+            </property>
+            <property name="scaledContents">
+             <bool>false</bool>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="7" column="2">
+          <item row="11" column="0">
+           <widget class="QLabel" name="lbl_PilotsNameAndHomeBase">
+            <property name="toolTip">
+             <string>pilot's name</string>
+            </property>
+            <property name="text">
+             <string>17. Pilot / homebase</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="4">
+           <widget class="QPlainTextEdit" name="pte_Route">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>75</height>
+             </size>
+            </property>
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="lbl_TakeOffTimePlanned">
+            <property name="text">
+             <string>9. Departure time</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLineEdit" name="le_CruiseTrueAirspeed">
+            <property name="maxLength">
+             <number>40</number>
+            </property>
+            <property name="placeholderText">
+             <string>e.g. 100 kts</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="2">
            <widget class="QLineEdit" name="le_FuelOnBoard">
             <property name="inputMask">
              <string>99:99</string>
@@ -443,23 +227,63 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="lbl_DestinationAirport">
+          <item row="5" column="3">
+           <layout class="QGridLayout" name="gl_CruiseAltitude">
+            <item row="0" column="0">
+             <widget class="BlackGui::CAltitudeEdit" name="lep_CrusingAltitude"/>
+            </item>
+            <item row="0" column="1">
+             <widget class="QToolButton" name="tb_AltitudeDialog">
+              <property name="toolTip">
+               <string>altitude formats</string>
+              </property>
+              <property name="whatsThis">
+               <string>altitude formats</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../blackmisc/blackmisc.qrc">
+                <normaloff>:/pastel/icons/pastel/16/help.png</normaloff>:/pastel/icons/pastel/16/help.png</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLabel" name="lbl_EstimatedTimeEnroute">
+            <property name="toolTip">
+             <string>Estimated time enroute</string>
+            </property>
             <property name="text">
-             <string>9. Destination airport</string>
+             <string>13. Est.time enroute</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QLineEdit" name="le_PrefixIcaoSuffix">
+          <item row="5" column="2">
+           <widget class="QLineEdit" name="le_TakeOffTimePlanned">
+            <property name="inputMask">
+             <string>99:99</string>
+            </property>
+            <property name="text">
+             <string>00:00</string>
+            </property>
+            <property name="maxLength">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="3">
+           <widget class="QLineEdit" name="le_PilotsHomeBase">
             <property name="readOnly">
              <bool>true</bool>
             </property>
             <property name="placeholderText">
-             <string>P/ICAO/S</string>
+             <string>homebase (read only)</string>
             </property>
            </widget>
           </item>
@@ -508,20 +332,40 @@
             </layout>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="le_OriginAirport">
-            <property name="maxLength">
-             <number>4</number>
+          <item row="9" column="2">
+           <widget class="QPushButton" name="pb_RemarksGenerator">
+            <property name="toolTip">
+             <string>goto generator page</string>
             </property>
-            <property name="placeholderText">
-             <string>ICAO, e.g. EDDF</string>
+            <property name="text">
+             <string>goto gen.</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="lbl_Callsign">
+          <item row="12" column="0">
+           <widget class="QLabel" name="lbl_LastSent">
             <property name="text">
-             <string>2. Callsign</string>
+             <string>Sent</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="3">
+           <widget class="QPushButton" name="pb_GetFromGenerator">
+            <property name="toolTip">
+             <string>copy from generator page</string>
+            </property>
+            <property name="text">
+             <string>from gen.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbl_AircraftType">
+            <property name="toolTip">
+             <string>Aircraft type</string>
+            </property>
+            <property name="text">
+             <string>3. Aircraft</string>
             </property>
             <property name="scaledContents">
              <bool>false</bool>
@@ -531,47 +375,234 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
-           <widget class="QLabel" name="lbl_CrusingAltitude">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbl_Type">
             <property name="text">
-             <string>7. Cruising altitude</string>
+             <string>1. Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QComboBox" name="cb_FlightRule">
+            <item>
+             <property name="text">
+              <string>IFR</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>VFR</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>SVFR</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>DVFR</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLineEdit" name="le_EstimatedTimeEnroute">
+            <property name="inputMask">
+             <string>99:99</string>
+            </property>
+            <property name="text">
+             <string>00:00</string>
+            </property>
+            <property name="placeholderText">
+             <string>hh:mm e.g. 02:30</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="lbl_DestinationAirport">
+            <property name="text">
+             <string>12. Destination airport</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
-           <widget class="QComboBox" name="cb_VoiceCapabilitiesFirstPage">
-            <item>
-             <property name="text">
-              <string>Full voice</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Text only</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Receive voice</string>
-             </property>
-            </item>
+          <item row="1" column="2">
+           <widget class="QLineEdit" name="le_AircraftType">
+            <property name="placeholderText">
+             <string>ICAO, e.g. A321</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="le_OriginAirport">
+            <property name="maxLength">
+             <number>4</number>
+            </property>
+            <property name="placeholderText">
+             <string>ICAO, e.g. EDDF</string>
+            </property>
            </widget>
           </item>
           <item row="4" column="3">
-           <layout class="QGridLayout" name="gl_CruiseAltitude">
+           <widget class="QLabel" name="lbl_CrusingAltitude">
+            <property name="text">
+             <string>10. Cruising altitude</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLabel" name="lbl_CruiseTrueAirspeed">
+            <property name="toolTip">
+             <string>True airspeed</string>
+            </property>
+            <property name="text">
+             <string>7. TAS</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="lbl_OriginAirport">
+            <property name="text">
+             <string>8. Departure airport</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1" colspan="2">
+           <widget class="QLineEdit" name="le_PilotsName">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="placeholderText">
+             <string>pilot's name (read only)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QLabel" name="lbl_FuelOnBoard">
+            <property name="text">
+             <string>14. Fuel on board</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLineEdit" name="le_DestinationAirport">
+            <property name="maxLength">
+             <number>4</number>
+            </property>
+            <property name="placeholderText">
+             <string>ICAO, e.g. EDDF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <widget class="QLineEdit" name="le_AlternateAirport">
+            <property name="maxLength">
+             <number>4</number>
+            </property>
+            <property name="placeholderText">
+             <string>ICAO, e.g. EDDF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QLabel" name="lbl_AlternateAirport">
+            <property name="text">
+             <string>15. Alternate airport</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QPushButton" name="pb_Remarks">
+            <property name="text">
+             <string>16. remarks</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1" colspan="3">
+           <widget class="QLineEdit" name="le_LastSent">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="placeholderText">
+             <string>sent time will go here (read only)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>4. Wake Turbulence Category</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="lbl_Route">
+            <property name="text">
+             <string>11. Route</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QGridLayout" name="gl_SsrEquipment">
             <item row="0" column="0">
-             <widget class="BlackGui::CAltitudeEdit" name="lep_CrusingAltitude"/>
+             <widget class="QLineEdit" name="le_SsrEquipment"/>
             </item>
             <item row="0" column="1">
-             <widget class="QToolButton" name="tb_AltitudeDialog">
+             <widget class="QToolButton" name="tb_EditSsrEquipment">
               <property name="toolTip">
-               <string>altitude formats</string>
+               <string>Edit</string>
               </property>
               <property name="whatsThis">
-               <string>altitude formats</string>
+               <string>Edit SSR equipment code</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../blackmisc/blackmisc.qrc">
+                <normaloff>:/pastel/icons/pastel/16/pencil.png</normaloff>:/pastel/icons/pastel/16/pencil.png</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <layout class="QHBoxLayout" name="hl_navCom">
+            <item>
+             <widget class="QLabel" name="lbl_NavCom">
+              <property name="text">
+               <string>5. NAV/COM Equipment</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="tb_NavComHelp">
+              <property name="toolTip">
+               <string>NAV/COM equipment overview</string>
+              </property>
+              <property name="whatsThis">
+               <string>NAV/COM equipment overview</string>
               </property>
               <property name="text">
                <string>...</string>
@@ -584,48 +615,33 @@
             </item>
            </layout>
           </item>
-          <item row="7" column="0">
-           <widget class="QLineEdit" name="le_DestinationAirport">
-            <property name="maxLength">
-             <number>4</number>
-            </property>
-            <property name="placeholderText">
-             <string>ICAO, e.g. EDDF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="lbl_TakeOffTimePlanned">
-            <property name="text">
-             <string>6. Departure time</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" alignment="Qt::AlignBottom">
-           <widget class="QLabel" name="lbl_Route">
-            <property name="text">
-             <string>8. Route</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QLineEdit" name="le_EstimatedTimeEnroute">
-            <property name="inputMask">
-             <string>99:99</string>
-            </property>
-            <property name="text">
-             <string>00:00</string>
-            </property>
-            <property name="placeholderText">
-             <string>hh:mm e.g. 02:30</string>
-            </property>
-           </widget>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="hl_Ssr">
+            <item>
+             <widget class="QLabel" name="lbl_Ssr">
+              <property name="text">
+               <string>6. SSR Equipment</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="tb_SsrHelp">
+              <property name="toolTip">
+               <string>SSR equipment overview</string>
+              </property>
+              <property name="whatsThis">
+               <string>SSR equipment overview</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../blackmisc/blackmisc.qrc">
+                <normaloff>:/pastel/icons/pastel/16/help.png</normaloff>:/pastel/icons/pastel/16/help.png</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
@@ -819,8 +835,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>382</width>
-         <height>477</height>
+         <width>345</width>
+         <height>520</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="vl_RemarksGeneratorScroll">
@@ -1167,68 +1183,6 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="tb_EquipmentCodes">
-   <attribute name="title">
-    <string>Equipment codes</string>
-   </attribute>
-   <layout class="QVBoxLayout" name="vl_EquipmentCodes">
-    <property name="leftMargin">
-     <number>4</number>
-    </property>
-    <property name="topMargin">
-     <number>4</number>
-    </property>
-    <property name="rightMargin">
-     <number>4</number>
-    </property>
-    <property name="bottomMargin">
-     <number>4</number>
-    </property>
-    <item>
-     <widget class="QTextBrowser" name="tbr_EquipmentCodes">
-      <property name="html">
-       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.1pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;FAA equipment codes&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; (Wikipedia) &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;NO DME:&lt;/li&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/X No transponder&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/T Transponder with no Mode C&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/U Transponder with Mode C&lt;/li&gt;&lt;/ul&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;DME:&lt;/li&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/D No transponder&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/B Transponder with no Mode C&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/A Transponder with Mode C&lt;/li&gt;&lt;/ul&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;TACAN only:&lt;/li&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/M No transponder&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/N Transponder with no Mode C&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/P Transponder with Mode C&lt;/li&gt;&lt;/ul&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Basic RNAV:&lt;/li&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/Y LORAN, VOR/DME, or INS with no transponder&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/C LORAN, VOR/DME, or INS, transponder with no Mode C&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/I LORAN, VOR/DME, or INS, transponder with Mode C&lt;/li&gt;&lt;/ul&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Advanced RNAV with Transponder and mode C:&lt;/li&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/L RNAV capability with Global Navigation Satellite System (GNSS), including GPS or Wide Area Augmentation System (WAAS) with en route and terminal capability, and with RVSM&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/G RNAV capability with GNSS and without RVSM&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/Z RNAV capability without GNSS and with RVSM&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/I RNAV capability without GNSS and without RVSM&lt;/li&gt;&lt;/ul&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RVSM (Reduced Vertical Separation Minimum):&lt;/li&gt;&lt;/ul&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/W RVSM&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/L RVSM and /G &lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;SquawkBox codes&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; (complemtary, obsolete)&lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt; &lt;/span&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/E Flight Management System (FMS) with DME/DME and IRU positioning updating&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/F Flight Management System (FMS) with DME/DME positioning updating&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/G Global Navigation Satellite System (GNSS), including GPS or Wide Area Augmentation System&lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/R Required navigation performance, the aircraft meets the RNP type prescribed for the route segment(s), route(s) and or area concerned &lt;/li&gt;
-&lt;li style=&quot; font-size:8pt;&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;/J /K /L /Q same as /E /F /G /R with RVSM&lt;/li&gt;&lt;/ul&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
  </widget>
  <customwidgets>
   <customwidget>
@@ -1244,26 +1198,23 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>sa_FlightPlanTabMain</tabstop>
-  <tabstop>cb_Heavy</tabstop>
-  <tabstop>cb_Tcas</tabstop>
-  <tabstop>le_PrefixIcaoSuffix</tabstop>
-  <tabstop>le_EquipmentSuffix</tabstop>
-  <tabstop>tb_HelpEquipment</tabstop>
-  <tabstop>pte_Route</tabstop>
+  <tabstop>cb_FlightRule</tabstop>
+  <tabstop>le_Callsign</tabstop>
+  <tabstop>le_AircraftType</tabstop>
+  <tabstop>cb_Wtc</tabstop>
+  <tabstop>tb_EditNavComEquipment</tabstop>
+  <tabstop>tb_EditSsrEquipment</tabstop>
+  <tabstop>le_CruiseTrueAirspeed</tabstop>
   <tabstop>le_OriginAirport</tabstop>
   <tabstop>le_TakeOffTimePlanned</tabstop>
   <tabstop>lep_CrusingAltitude</tabstop>
-  <tabstop>tb_AltitudeDialog</tabstop>
+  <tabstop>pte_Route</tabstop>
   <tabstop>le_DestinationAirport</tabstop>
   <tabstop>le_EstimatedTimeEnroute</tabstop>
   <tabstop>le_FuelOnBoard</tabstop>
   <tabstop>le_AlternateAirport</tabstop>
-  <tabstop>pb_Remarks</tabstop>
-  <tabstop>cb_VoiceCapabilitiesFirstPage</tabstop>
-  <tabstop>pb_RemarksGenerator</tabstop>
-  <tabstop>pb_GetFromGenerator</tabstop>
   <tabstop>pte_Remarks</tabstop>
+  <tabstop>pb_GetFromGenerator</tabstop>
   <tabstop>le_PilotsName</tabstop>
   <tabstop>le_PilotsHomeBase</tabstop>
   <tabstop>le_LastSent</tabstop>
@@ -1292,12 +1243,16 @@ p, li { white-space: pre-wrap; }
   <tabstop>pb_AddRemarks</tabstop>
   <tabstop>pte_AdditionalRemarks</tabstop>
   <tabstop>pb_CopyOver</tabstop>
-  <tabstop>tbr_EquipmentCodes</tabstop>
-  <tabstop>le_CruiseTrueAirspeed</tabstop>
   <tabstop>tb_SyncWithSimulator</tabstop>
-  <tabstop>le_Callsign</tabstop>
-  <tabstop>le_AircraftType</tabstop>
-  <tabstop>cb_FlightRule</tabstop>
+  <tabstop>le_NavComEquipment</tabstop>
+  <tabstop>tb_AltitudeDialog</tabstop>
+  <tabstop>sa_FlightPlanTabMain</tabstop>
+  <tabstop>cb_VoiceCapabilitiesFirstPage</tabstop>
+  <tabstop>pb_Remarks</tabstop>
+  <tabstop>le_SsrEquipment</tabstop>
+  <tabstop>pb_RemarksGenerator</tabstop>
+  <tabstop>tb_NavComHelp</tabstop>
+  <tabstop>tb_SsrHelp</tabstop>
  </tabstops>
  <resources>
   <include location="../../blackmisc/blackmisc.qrc"/>

--- a/src/blackgui/components/flightplancomponent.ui
+++ b/src/blackgui/components/flightplancomponent.ui
@@ -872,7 +872,7 @@
           <property name="spacing">
            <number>6</number>
           </property>
-          <item row="6" column="1">
+          <item row="5" column="1">
            <widget class="QComboBox" name="cb_VoiceCapabilities">
             <item>
              <property name="text">
@@ -901,7 +901,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="lbl_RemarksGenerated">
             <property name="text">
              <string>Remarks</string>
@@ -911,7 +911,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="QComboBox" name="cb_PerformanceCategory">
             <property name="toolTip">
              <string>Final Approach Speed</string>
@@ -948,16 +948,6 @@
             </item>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="lbl_NavigationEquipment">
-            <property name="text">
-             <string>Navigation equipment</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="lbl_SidsStars">
             <property name="text">
@@ -965,7 +955,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="lbl_Selcal">
             <property name="text">
              <string>SELCAL</string>
@@ -982,7 +972,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="6" column="1">
            <widget class="QComboBox" name="cb_PilotRating">
             <item>
              <property name="text">
@@ -1016,7 +1006,7 @@
             </item>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="8" column="1">
            <widget class="QPlainTextEdit" name="pte_RemarksGenerated">
             <property name="maximumSize">
              <size>
@@ -1032,7 +1022,7 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
+          <item row="10" column="1">
            <widget class="QPlainTextEdit" name="pte_AdditionalRemarks">
             <property name="maximumSize">
              <size>
@@ -1055,7 +1045,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="lbl_PerformanceCategory">
             <property name="text">
              <string>Performance category</string>
@@ -1065,7 +1055,7 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="1">
+          <item row="12" column="1">
            <widget class="QFrame" name="fr_Buttons">
             <property name="frameShape">
              <enum>QFrame::StyledPanel</enum>
@@ -1084,7 +1074,7 @@
             </layout>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QComboBox" name="cb_RequiredNavigationPerformance">
             <item>
              <property name="text">
@@ -1106,7 +1096,7 @@
           <item row="1" column="1">
            <widget class="QLineEdit" name="le_AircraftRegistration"/>
           </item>
-          <item row="4" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="lbl_RequiredNavigationPerformance">
             <property name="text">
              <string>Required Navigation Performance</string>
@@ -1116,17 +1106,17 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="lbl_PilotRating">
             <property name="text">
              <string>Pilot rating</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="7" column="1">
            <widget class="BlackGui::Components::CSelcalCodeSelector" name="frp_SelcalCode"/>
           </item>
-          <item row="6" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="lbl_VoiceCapabilities">
             <property name="text">
              <string>Voice capabilities</string>
@@ -1136,39 +1126,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="cb_NavigationEquipment">
-            <property name="toolTip">
-             <string>How will you be navigating?</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>VFR flying visually</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Direct VORs and NDBs</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Default GPS</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>GPS or FMC capable of SIDs/STARs</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>GPS oceanic certified</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="11" column="0" alignment="Qt::AlignTop">
+          <item row="10" column="0" alignment="Qt::AlignTop">
            <widget class="QPushButton" name="pb_AddRemarks">
             <property name="text">
              <string>add.remarks</string>
@@ -1234,7 +1192,6 @@
   <tabstop>le_AirlineOperator</tabstop>
   <tabstop>le_AircraftRegistration</tabstop>
   <tabstop>cb_NoSidsStarts</tabstop>
-  <tabstop>cb_NavigationEquipment</tabstop>
   <tabstop>cb_RequiredNavigationPerformance</tabstop>
   <tabstop>cb_PerformanceCategory</tabstop>
   <tabstop>cb_VoiceCapabilities</tabstop>

--- a/src/blackgui/components/modelmatchercomponent.cpp
+++ b/src/blackgui/components/modelmatchercomponent.cpp
@@ -266,7 +266,7 @@ namespace BlackGui::Components
     CAircraftModel CModelMatcherComponent::defaultModel() const
     {
         // can somehow dynamilcally determine the models
-        const CAircraftIcaoCode icaoAircraft("B737", "L2J", "FooBar", "Dummy", "M", false, false, false, 1);
+        const CAircraftIcaoCode icaoAircraft("B737", "L2J", "FooBar", "Dummy", CWakeTurbulenceCategory::MEDIUM, false, false, false, 1);
         const CAirlineIcaoCode icaoAirline("Foo", "FooBar airlines", { "DE", "Germany" }, "FOO", true, true);
         const CLivery livery(CLivery::getStandardCode(icaoAirline), icaoAirline, "Standard Foo airlines", "red", "blue", false);
         CAircraftModel model("default model", CAircraftModel::TypeOwnSimulatorModel, "dummy model", icaoAircraft, livery);

--- a/src/blackgui/editors/aircrafticaoform.cpp
+++ b/src/blackgui/editors/aircrafticaoform.cpp
@@ -73,7 +73,7 @@ namespace BlackGui::Editors
         ui->combined_TypeSelector->setCombinedType(icao.getCombinedType());
 
         QString rank(icao.getRankString());
-        QString wtc(icao.getWtc());
+        QString wtc(icao.getWtc().toQString());
         CGuiUtility::setComboBoxValueByStartingString(ui->cb_Rank, rank, "unspecified");
         CGuiUtility::setComboBoxValueByStartingString(ui->cb_Wtc, wtc, "unspecified");
 
@@ -134,7 +134,7 @@ namespace BlackGui::Editors
         bool realWorld = ui->cb_RealWorld->isChecked();
         icao.setManufacturer(manufacturer);
         icao.setModelDescription(modelDescription);
-        icao.setWtc(wtc);
+        icao.setWtc(wtc.isEmpty() ? CWakeTurbulenceCategory() : CWakeTurbulenceCategory(wtc.at(0)));
         icao.setCodeFlags(military, legacy, realWorld);
         icao.setRank(rank);
         icao.setCombinedType(combined);

--- a/src/blackgui/editors/fsdsetupform.cpp
+++ b/src/blackgui/editors/fsdsetupform.cpp
@@ -34,7 +34,7 @@ namespace BlackGui::Editors
             ui->cb_AircraftPartsSend->isChecked(), ui->cb_AircraftPartsReceive->isChecked(),
             ui->cb_GndFlagSend->isChecked(), ui->cb_GndFlagReceive->isChecked(),
             ui->cb_FastPositionSend->isChecked(), ui->cb_FastPositionReceive->isChecked(),
-            ui->cb_VisualPositionSend->isChecked(), ui->cb_EuroscopeSimData->isChecked());
+            ui->cb_VisualPositionSend->isChecked(), ui->cb_EuroscopeSimData->isChecked(), ui->cb_IcaoEquipment->isChecked());
         s.setForce3LetterAirlineCodes(ui->cb_3LetterAirlineICAO->isChecked());
         return s;
     }
@@ -56,6 +56,7 @@ namespace BlackGui::Editors
         ui->cb_FastPositionSend->setChecked(d & CFsdSetup::SendInterimPositions);
         ui->cb_3LetterAirlineICAO->setChecked(setup.force3LetterAirlineCodes());
         ui->cb_EuroscopeSimData->setChecked(d & CFsdSetup::ReceiveEuroscopeSimData);
+        ui->cb_IcaoEquipment->setChecked(d & CFsdSetup::SendFplWithIcaoEquipment);
     }
 
     void CFsdSetupForm::setAlwaysAllowOverride(bool allow)

--- a/src/blackgui/editors/fsdsetupform.ui
+++ b/src/blackgui/editors/fsdsetupform.ui
@@ -29,6 +29,34 @@
    <property name="spacing">
     <number>4</number>
    </property>
+   <item row="0" column="1">
+    <widget class="QLabel" name="lbl_FsdSetup">
+     <property name="text">
+      <string>FSD setup:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="cb_AircraftPartsSend">
+     <property name="text">
+      <string>send</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QCheckBox" name="cb_AircraftPartsReceive">
+     <property name="text">
+      <string>receive</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QCheckBox" name="cb_Override">
+     <property name="text">
+      <string>override</string>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="1">
     <widget class="QLabel" name="lbl_AircraftParts">
      <property name="toolTip">
@@ -39,31 +67,10 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="3">
-    <widget class="QCheckBox" name="cb_FastPositionSend">
-     <property name="text">
-      <string>send</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QCheckBox" name="cb_GndFlagSend">
-     <property name="text">
-      <string>send</string>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="2">
     <widget class="QLabel" name="lbl_GndFlag">
      <property name="text">
       <string>Gnd.flag</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="cb_AircraftPartsReceive">
-     <property name="text">
-      <string>receive</string>
      </property>
     </widget>
    </item>
@@ -81,31 +88,10 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
-    <widget class="QCheckBox" name="cb_GndFlagReceive">
-     <property name="text">
-      <string>receive</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="cb_AircraftPartsSend">
+   <item row="5" column="2">
+    <widget class="QCheckBox" name="cb_GndFlagSend">
      <property name="text">
       <string>send</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="5">
-    <widget class="QLabel" name="lbl_TextCodec">
-     <property name="text">
-      <string>Text codec</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="5">
-    <widget class="QLineEdit" name="le_TextCodec">
-     <property name="placeholderText">
-      <string>e.g. &quot;latin1&quot;</string>
      </property>
     </widget>
    </item>
@@ -113,20 +99,6 @@
     <widget class="QPushButton" name="pb_SetDefaults">
      <property name="text">
       <string>set defaults</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QCheckBox" name="cb_Override">
-     <property name="text">
-      <string>override</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="lbl_FsdSetup">
-     <property name="text">
-      <string>FSD setup:</string>
      </property>
     </widget>
    </item>
@@ -140,10 +112,24 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="4">
-    <widget class="QCheckBox" name="cb_VisualPositionSend">
+   <item row="5" column="3">
+    <widget class="QCheckBox" name="cb_FastPositionSend">
      <property name="text">
-      <string>Send visual pos.</string>
+      <string>send</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="5">
+    <widget class="QLabel" name="lbl_TextCodec">
+     <property name="text">
+      <string>Text codec</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QCheckBox" name="cb_GndFlagReceive">
+     <property name="text">
+      <string>receive</string>
      </property>
     </widget>
    </item>
@@ -157,21 +143,43 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="5">
+    <widget class="QLineEdit" name="le_TextCodec">
+     <property name="placeholderText">
+      <string>e.g. &quot;latin1&quot;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="4">
+    <widget class="QCheckBox" name="cb_VisualPositionSend">
+     <property name="text">
+      <string>Send visual pos.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="6">
+    <widget class="QCheckBox" name="cb_IcaoEquipment">
+     <property name="text">
+      <string>ICAO Equipment</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>cb_Override</tabstop>
-  <tabstop>pb_SetDefaults</tabstop>
   <tabstop>cb_AircraftPartsSend</tabstop>
-  <tabstop>cb_AircraftPartsReceive</tabstop>
   <tabstop>cb_GndFlagSend</tabstop>
-  <tabstop>cb_GndFlagReceive</tabstop>
   <tabstop>cb_FastPositionSend</tabstop>
-  <tabstop>cb_FastPositionReceive</tabstop>
   <tabstop>cb_VisualPositionSend</tabstop>
-  <tabstop>cb_EuroscopeSimData</tabstop>
   <tabstop>le_TextCodec</tabstop>
+  <tabstop>cb_IcaoEquipment</tabstop>
+  <tabstop>cb_AircraftPartsReceive</tabstop>
+  <tabstop>cb_GndFlagReceive</tabstop>
+  <tabstop>cb_FastPositionReceive</tabstop>
+  <tabstop>cb_EuroscopeSimData</tabstop>
   <tabstop>cb_3LetterAirlineICAO</tabstop>
+  <tabstop>pb_SetDefaults</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/blackmisc/CMakeLists.txt
+++ b/src/blackmisc/CMakeLists.txt
@@ -99,6 +99,8 @@ add_library(misc SHARED
         aviation/track.h
         aviation/transponder.cpp
         aviation/transponder.h
+        aviation/waketurbulencecategory.cpp
+        aviation/waketurbulencecategory.h
 
         # DB
         db/artifact.cpp

--- a/src/blackmisc/CMakeLists.txt
+++ b/src/blackmisc/CMakeLists.txt
@@ -71,10 +71,14 @@ add_library(misc SHARED
         aviation/callsignobjectlist.h
         aviation/callsignset.cpp
         aviation/callsignset.h
+        aviation/comnavequipment.cpp
+        aviation/comnavequipment.h
         aviation/comsystem.cpp
         aviation/comsystem.h
         aviation/flightplan.cpp
         aviation/flightplan.h
+        aviation/flightplanaircraftinfo.cpp
+        aviation/flightplanaircraftinfo.h
         aviation/flightplanlist.cpp
         aviation/flightplanlist.h
         aviation/heading.cpp
@@ -95,6 +99,8 @@ add_library(misc SHARED
         aviation/selcal.h
         aviation/simbriefdata.cpp
         aviation/simbriefdata.h
+        aviation/ssrequipment.cpp
+        aviation/ssrequipment.h
         aviation/track.cpp
         aviation/track.h
         aviation/transponder.cpp

--- a/src/blackmisc/aviation/aircrafticaocode.cpp
+++ b/src/blackmisc/aviation/aircrafticaocode.cpp
@@ -78,7 +78,7 @@ namespace BlackMisc::Aviation
     void CAircraftIcaoCode::updateMissingParts(const CAircraftIcaoCode &otherIcaoCode)
     {
         if (!this->hasValidDesignator() && otherIcaoCode.hasValidDesignator()) { this->setDesignator(otherIcaoCode.getDesignator()); }
-        if (!this->hasValidWtc() && otherIcaoCode.hasValidWtc()) { this->setWtc(otherIcaoCode.getDesignator()); }
+        if (!this->hasValidWtc() && otherIcaoCode.hasValidWtc()) { this->setWtc(otherIcaoCode.getWtc()); }
         if (!this->hasValidCombinedType() && otherIcaoCode.hasValidCombinedType()) { this->setCombinedType(otherIcaoCode.getCombinedType()); }
         if (m_manufacturer.isEmpty()) { this->setManufacturer(otherIcaoCode.getManufacturer()); }
         if (m_modelDescription.isEmpty()) { this->setModelDescription(otherIcaoCode.getModelDescription()); }

--- a/src/blackmisc/aviation/aircrafticaocode.h
+++ b/src/blackmisc/aviation/aircrafticaocode.h
@@ -7,6 +7,7 @@
 #define BLACKMISC_AVIATION_AIRCRAFTICAOCODE_H
 
 #include "blackmisc/aviation/aircraftcategory.h"
+#include "blackmisc/aviation/waketurbulencecategory.h"
 #include "blackmisc/db/datastore.h"
 #include "blackmisc/pq/length.h"
 #include "blackmisc/blackmiscexport.h"
@@ -60,15 +61,15 @@ namespace BlackMisc::Aviation
 
         //! Constructor
         CAircraftIcaoCode(const QString &icao, const QString &combinedType, const QString &manufacturer,
-                          const QString &model, const QString &wtc, bool realworld, bool legacy, bool military, int rank);
+                          const QString &model, CWakeTurbulenceCategory wtc, bool realworld, bool legacy, bool military, int rank);
 
         //! Constructor
         CAircraftIcaoCode(const QString &icao, const QString &iata, const QString &combinedType, const QString &manufacturer,
-                          const QString &model, const QString &wtc, bool realworld, bool legacy, bool military, int rank);
+                          const QString &model, CWakeTurbulenceCategory wtc, bool realworld, bool legacy, bool military, int rank);
 
         //! Constructor
         CAircraftIcaoCode(const QString &icao, const QString &iata, const QString &family, const QString &combinedType, const QString &manufacturer,
-                          const QString &model, const QString &modelIata, const QString &modelSwift, const QString &wtc, bool realworld, bool legacy, bool military, int rank);
+                          const QString &model, const QString &modelIata, const QString &modelSwift, CWakeTurbulenceCategory wtc, bool realworld, bool legacy, bool military, int rank);
 
         //! Get ICAO designator, e.g. "B737"
         const QString &getDesignator() const { return m_designator; }
@@ -198,13 +199,13 @@ namespace BlackMisc::Aviation
         bool matchesManufacturer(const QString &manufacturer) const;
 
         //! Get WTC
-        const QString &getWtc() const { return m_wtc; }
+        CWakeTurbulenceCategory getWtc() const { return m_wtc; }
 
         //! Set WTC
-        void setWtc(const QString &wtc) { m_wtc = wtc.trimmed().toUpper(); }
+        void setWtc(CWakeTurbulenceCategory wtc) { m_wtc = wtc; }
 
         //! Valid WTC code?
-        bool hasValidWtc() const { return !m_wtc.isEmpty(); }
+        bool hasValidWtc() const { return !m_wtc.isUnknown(); }
 
         //! Is VTOL aircraft (helicopter, tilt wing)
         bool isVtol() const;
@@ -376,7 +377,7 @@ namespace BlackMisc::Aviation
         QString m_modelDescription; //!< "A-330-200", the ICAO description
         QString m_modelIataDescription; //!< alternative IATA description
         QString m_modelSwiftDescription; //!< alternative swift description
-        QString m_wtc; //!< wake turbulence like "M","H" "L/M", "L", "J", we only use the one letter versions
+        CWakeTurbulenceCategory m_wtc; //!< ICAO wake turbulence category
         bool m_realWorld = true; //!< real world aircraft
         bool m_legacy = false; //!< legacy code
         bool m_military = false; //!< military aircraft?

--- a/src/blackmisc/aviation/comnavequipment.cpp
+++ b/src/blackmisc/aviation/comnavequipment.cpp
@@ -1,0 +1,212 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#include "comnavequipment.h"
+
+BLACK_DEFINE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CComNavEquipment)
+
+namespace BlackMisc::Aviation
+{
+    CComNavEquipment::CComNavEquipment(ComNavEquipment comNavEquipment, CpdlcSatcomEquipment cpdlcSatcomEquipment) : m_equipment(comNavEquipment), m_cpdlcSatcomEquipment(cpdlcSatcomEquipment)
+    {
+        if (m_equipment == ComNavEquipment())
+        {
+            m_equipment = NoEquip;
+        }
+    }
+
+    CComNavEquipment::CComNavEquipment(QString equipment)
+    {
+        if (equipment.isEmpty())
+        {
+            return;
+        }
+
+        m_equipment = {}; // Clear default flag
+
+        auto append_equipment_flag_if_exist = [&equipment, this](ComNavEquipmentOption flag) {
+            QString str = flagToString(flag);
+            if (equipment.contains(str))
+            {
+                equipment = equipment.remove(str);
+                m_equipment |= flag;
+            }
+        };
+
+        auto append_satcom_flag_if_exist = [&equipment, this](CpdlcSatcomEquipmentOption flag) {
+            QString str = flagToString(flag);
+            if (equipment.contains(str))
+            {
+                equipment = equipment.remove(str);
+                m_cpdlcSatcomEquipment |= flag;
+            }
+        };
+
+        append_equipment_flag_if_exist(Standard);
+        append_equipment_flag_if_exist(Gbas);
+        append_equipment_flag_if_exist(Lpv);
+        append_equipment_flag_if_exist(LoranC);
+        append_equipment_flag_if_exist(Dme);
+        append_equipment_flag_if_exist(FmcAcars);
+        append_equipment_flag_if_exist(DFisAcars);
+        append_equipment_flag_if_exist(PdcAcars);
+        append_equipment_flag_if_exist(Adf);
+        append_equipment_flag_if_exist(Gnss);
+        append_equipment_flag_if_exist(HfRtf);
+        append_equipment_flag_if_exist(InertiaNavigation);
+        append_equipment_flag_if_exist(Mls);
+        append_equipment_flag_if_exist(Ils);
+        append_equipment_flag_if_exist(NoEquip);
+        append_equipment_flag_if_exist(Vor);
+        append_equipment_flag_if_exist(Pbn);
+        append_equipment_flag_if_exist(Tacan);
+        append_equipment_flag_if_exist(UhfRtf);
+        append_equipment_flag_if_exist(VhfRtf);
+        append_equipment_flag_if_exist(Rvsm);
+        append_equipment_flag_if_exist(Mnps);
+        append_equipment_flag_if_exist(Vhf833);
+        append_equipment_flag_if_exist(Other);
+        append_satcom_flag_if_exist(CpdlcAtn);
+        append_satcom_flag_if_exist(CpdlcFansHfdl);
+        append_satcom_flag_if_exist(CpdlcFansVdlA);
+        append_satcom_flag_if_exist(CpdlcFansVdl2);
+        append_satcom_flag_if_exist(CpdlcFansSatcomInmarsat);
+        append_satcom_flag_if_exist(CpdlcFansSatcomMtsat);
+        append_satcom_flag_if_exist(CpdlcFansSatcomIridium);
+        append_satcom_flag_if_exist(AtcSatvoiceInmarsat);
+        append_satcom_flag_if_exist(AtcSatvoiceMtsat);
+        append_satcom_flag_if_exist(AtcSatvoiceIridium);
+        append_satcom_flag_if_exist(CpdlcRcp400);
+        append_satcom_flag_if_exist(CpdlcRcp240);
+        append_satcom_flag_if_exist(SatvoiceRcp400);
+
+        if (!equipment.isEmpty() && m_equipment == ComNavEquipment())
+        {
+            // Default if nothing correct is provided
+            m_equipment = NoEquip;
+            m_cpdlcSatcomEquipment = {};
+        }
+    }
+
+    QStringList CComNavEquipment::enabledOptions() const
+    {
+        QStringList list;
+
+        auto append_equipment_flag_if_exist = [&list, this](ComNavEquipmentOption flag) {
+            if (m_equipment.testFlag(flag)) list << flagToString(flag);
+        };
+
+        auto append_satcom_flag_if_exist = [&list, this](CpdlcSatcomEquipmentOption flag) {
+            if (m_cpdlcSatcomEquipment.testFlag(flag)) list << flagToString(flag);
+        };
+
+        append_equipment_flag_if_exist(Standard);
+        append_equipment_flag_if_exist(Gbas);
+        append_equipment_flag_if_exist(Lpv);
+        append_equipment_flag_if_exist(LoranC);
+        append_equipment_flag_if_exist(Dme);
+        append_equipment_flag_if_exist(FmcAcars);
+        append_equipment_flag_if_exist(DFisAcars);
+        append_equipment_flag_if_exist(PdcAcars);
+        append_equipment_flag_if_exist(Adf);
+        append_equipment_flag_if_exist(Gnss);
+        append_equipment_flag_if_exist(HfRtf);
+        append_equipment_flag_if_exist(InertiaNavigation);
+        append_satcom_flag_if_exist(CpdlcAtn);
+        append_satcom_flag_if_exist(CpdlcFansHfdl);
+        append_satcom_flag_if_exist(CpdlcFansVdlA);
+        append_satcom_flag_if_exist(CpdlcFansVdl2);
+        append_satcom_flag_if_exist(CpdlcFansSatcomInmarsat);
+        append_satcom_flag_if_exist(CpdlcFansSatcomMtsat);
+        append_satcom_flag_if_exist(CpdlcFansSatcomIridium);
+        append_equipment_flag_if_exist(Mls);
+        append_equipment_flag_if_exist(Ils);
+        append_satcom_flag_if_exist(AtcSatvoiceInmarsat);
+        append_satcom_flag_if_exist(AtcSatvoiceMtsat);
+        append_satcom_flag_if_exist(AtcSatvoiceIridium);
+        append_equipment_flag_if_exist(NoEquip);
+        append_equipment_flag_if_exist(Vor);
+        append_satcom_flag_if_exist(CpdlcRcp400);
+        append_satcom_flag_if_exist(CpdlcRcp240);
+        append_satcom_flag_if_exist(SatvoiceRcp400);
+        append_equipment_flag_if_exist(Pbn);
+        append_equipment_flag_if_exist(Tacan);
+        append_equipment_flag_if_exist(UhfRtf);
+        append_equipment_flag_if_exist(VhfRtf);
+        append_equipment_flag_if_exist(Rvsm);
+        append_equipment_flag_if_exist(Mnps);
+        append_equipment_flag_if_exist(Vhf833);
+        append_equipment_flag_if_exist(Other);
+
+        return list;
+    }
+
+    QString CComNavEquipment::convertToQString(bool) const
+    {
+        const QString equipmentString = enabledOptions().join("");
+        Q_ASSERT_X(!equipmentString.isEmpty(), Q_FUNC_INFO, "Equipment string should not be empty");
+        return equipmentString;
+    }
+
+    QString CComNavEquipment::flagToString(CpdlcSatcomEquipmentOption flag)
+    {
+        switch (flag)
+        {
+        case CpdlcAtn: return QStringLiteral("J1");
+        case CpdlcFansHfdl: return QStringLiteral("J2");
+        case CpdlcFansVdlA: return QStringLiteral("J3");
+        case CpdlcFansVdl2: return QStringLiteral("J4");
+        case CpdlcFansSatcomInmarsat: return QStringLiteral("J5");
+        case CpdlcFansSatcomMtsat: return QStringLiteral("J6");
+        case CpdlcFansSatcomIridium: return QStringLiteral("J7");
+        case AtcSatvoiceInmarsat: return QStringLiteral("M1");
+        case AtcSatvoiceMtsat: return QStringLiteral("M2");
+        case AtcSatvoiceIridium: return QStringLiteral("M3");
+        case CpdlcRcp400: return QStringLiteral("P1");
+        case CpdlcRcp240: return QStringLiteral("P2");
+        case SatvoiceRcp400: return QStringLiteral("P3");
+        default: return {};
+        }
+    }
+
+    QString CComNavEquipment::flagToString(ComNavEquipmentOption flag)
+    {
+        switch (flag)
+        {
+        case Standard: return QStringLiteral("S");
+        case Gbas: return QStringLiteral("A");
+        case Lpv: return QStringLiteral("B");
+        case LoranC: return QStringLiteral("C");
+        case Dme: return QStringLiteral("D");
+        case FmcAcars: return QStringLiteral("E1");
+        case DFisAcars: return QStringLiteral("E2");
+        case PdcAcars: return QStringLiteral("E3");
+        case Adf: return QStringLiteral("F");
+        case Gnss: return QStringLiteral("G");
+        case HfRtf: return QStringLiteral("H");
+        case InertiaNavigation: return QStringLiteral("I");
+        case Mls: return QStringLiteral("K");
+        case Ils: return QStringLiteral("L");
+        case NoEquip: return QStringLiteral("N");
+        case Vor: return QStringLiteral("O");
+        case Pbn: return QStringLiteral("R");
+        case Tacan: return QStringLiteral("T");
+        case UhfRtf: return QStringLiteral("U");
+        case VhfRtf: return QStringLiteral("V");
+        case Rvsm: return QStringLiteral("W");
+        case Mnps: return QStringLiteral("X");
+        case Vhf833: return QStringLiteral("Y");
+        case Other: return QStringLiteral("Z");
+        default: return {};
+        }
+    }
+
+    QStringList CComNavEquipment::allEquipmentLetters()
+    {
+        // In order as they appear in the final string
+        static const QStringList r({ "S", "A", "B", "C", "D", "E1", "E2", "E3", "F", "G", "H", "I", "J1", "J2", "J3", "J4", "J5", "J6", "J7", "K", "L", "M1", "M2", "M3",
+                                     "N", "O", "P1", "P2", "P3", "R", "T", "U", "V", "W", "X", "Y", "Z" });
+        return r;
+    }
+
+}

--- a/src/blackmisc/aviation/comnavequipment.h
+++ b/src/blackmisc/aviation/comnavequipment.h
@@ -1,0 +1,116 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#ifndef BLACKMISC_AVIATION_COMNAVEQUIPMENT_H
+#define BLACKMISC_AVIATION_COMNAVEQUIPMENT_H
+
+#include "blackmisc/blackmiscexport.h"
+#include "blackmisc/valueobject.h"
+
+BLACK_DECLARE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CComNavEquipment)
+
+namespace BlackMisc::Aviation
+{
+    //! ICAO flightplan field 10a
+    class BLACKMISC_EXPORT CComNavEquipment : public BlackMisc::CValueObject<CComNavEquipment>
+    {
+    public:
+        // QFlag uses int as an underlying type. Hence, the equipment is split up into two enums.
+        // Once Qt adds a QFlag64, these can be united.
+        // See https://bugreports.qt.io/browse/QTBUG-53178
+
+        //! CPLDC and SATCOM equipment options
+        enum CpdlcSatcomEquipmentOption : int
+        {
+            CpdlcAtn = (1 << 0),
+            CpdlcFansHfdl = (1 << 1),
+            CpdlcFansVdlA = (1 << 2),
+            CpdlcFansVdl2 = (1 << 3),
+            CpdlcFansSatcomInmarsat = (1 << 4),
+            CpdlcFansSatcomMtsat = (1 << 5),
+            CpdlcFansSatcomIridium = (1 << 6),
+            AtcSatvoiceInmarsat = (1 << 7),
+            AtcSatvoiceMtsat = (1 << 8),
+            AtcSatvoiceIridium = (1 << 9),
+            CpdlcRcp400 = (1 << 10),
+            CpdlcRcp240 = (1 << 11),
+            SatvoiceRcp400 = (1 << 12),
+        };
+
+        //! COM/NAV equipment options
+        enum ComNavEquipmentOption : int
+        {
+            Standard = (1 << 0),
+            Gbas = (1 << 1),
+            Lpv = (1 << 2),
+            LoranC = (1 << 3),
+            Dme = (1 << 4),
+            FmcAcars = (1 << 5),
+            DFisAcars = (1 << 6),
+            PdcAcars = (1 << 7),
+            Adf = (1 << 8),
+            Gnss = (1 << 9),
+            HfRtf = (1 << 10),
+            InertiaNavigation = (1 << 11),
+            Mls = (1 << 12),
+            Ils = (1 << 13),
+            NoEquip = (1 << 14),
+            Vor = (1 << 15),
+            Pbn = (1 << 16),
+            Tacan = (1 << 17),
+            UhfRtf = (1 << 18),
+            VhfRtf = (1 << 19),
+            Rvsm = (1 << 20),
+            Mnps = (1 << 21),
+            Vhf833 = (1 << 22),
+            Other = (1 << 23)
+        };
+
+        Q_DECLARE_FLAGS(ComNavEquipment, ComNavEquipmentOption);
+        Q_DECLARE_FLAGS(CpdlcSatcomEquipment, CpdlcSatcomEquipmentOption);
+
+        //! Create default equipment with Standard COM/NAV
+        CComNavEquipment() = default;
+
+        //! Create object with given COM/NAV, CPDLC and SATCOM equipment
+        CComNavEquipment(ComNavEquipment comNavEquipment, CpdlcSatcomEquipment cpdlcSatcomEquipment);
+
+        //! Create object from an ICAO equipment string (for example "SDE2E3FGHIJ1RWXY")
+        explicit CComNavEquipment(QString equipment);
+
+        //! Get all possible equipment code letters
+        static QStringList allEquipmentLetters();
+
+        //! @{
+        //! Does this object contains \p equip?
+        bool hasEquipment(ComNavEquipmentOption equip) const { return m_equipment.testFlag(equip); }
+        bool hasEquipment(CpdlcSatcomEquipmentOption equip) const { return m_cpdlcSatcomEquipment.testFlag(equip); }
+        //! @}
+
+        //! Get all enabled equipment codes of this object as a list
+        QStringList enabledOptions() const;
+
+        //! Get the equipment string of this object (for example "SDE2E3FGHIJ1RWXY")
+        QString convertToQString(bool i18n = false) const;
+
+    private:
+        //! @{
+        //! Get the string for the specific equipment
+        static QString flagToString(CpdlcSatcomEquipmentOption flag);
+        static QString flagToString(ComNavEquipmentOption flag);
+        //! @}
+
+        ComNavEquipment m_equipment = Standard;
+        CpdlcSatcomEquipment m_cpdlcSatcomEquipment;
+
+        BLACK_METACLASS(
+            CComNavEquipment,
+            BLACK_METAMEMBER(equipment),
+            BLACK_METAMEMBER(cpdlcSatcomEquipment)
+        );
+    };
+}
+
+Q_DECLARE_METATYPE(BlackMisc::Aviation::CComNavEquipment)
+
+#endif // BLACKMISC_AVIATION_COMNAVEQUIPMENT_H

--- a/src/blackmisc/aviation/flightplan.cpp
+++ b/src/blackmisc/aviation/flightplan.cpp
@@ -51,6 +51,8 @@ namespace BlackMisc::Aviation
     void CFlightPlanRemarks::setVoiceCapabilities(const CVoiceCapabilities &capabilities)
     {
         m_voiceCapabilities = capabilities;
+        const QString r = CFlightPlanRemarks::replaceVoiceCapabilities(m_voiceCapabilities.toFlightPlanRemarks(), m_remarks);
+        m_remarks = r;
     }
 
     bool CFlightPlanRemarks::hasAnyParsedRemarks() const

--- a/src/blackmisc/aviation/flightplan.h
+++ b/src/blackmisc/aviation/flightplan.h
@@ -99,9 +99,6 @@ namespace BlackMisc::Aviation
         //! Empty remarks?
         bool isEmpty() const { return m_remarks.isEmpty(); }
 
-        //! Equipment codes (ICAO)
-        void setIcaoEquipmentCodes(const QString &eq);
-
         //! Already parsed?
         bool isParsed() const { return m_isParsed; }
 

--- a/src/blackmisc/aviation/flightplan.h
+++ b/src/blackmisc/aviation/flightplan.h
@@ -12,6 +12,7 @@
 #include "blackmisc/aviation/airlineicaocode.h"
 #include "blackmisc/aviation/callsign.h"
 #include "blackmisc/aviation/selcal.h"
+#include "blackmisc/aviation/flightplanaircraftinfo.h"
 #include "blackmisc/network/voicecapabilities.h"
 #include "blackmisc/network/url.h"
 #include "blackmisc/pq/speed.h"
@@ -185,16 +186,15 @@ namespace BlackMisc::Aviation
 
         //! Constructor
         CFlightPlan(const CCallsign &callsign,
-                    const QString &equipmentIcao, const CAirportIcaoCode &originAirportIcao, const CAirportIcaoCode &destinationAirportIcao, const CAirportIcaoCode &alternateAirportIcao,
+                    const CFlightPlanAircraftInfo &aircraftInfo, const CAirportIcaoCode &originAirportIcao, const CAirportIcaoCode &destinationAirportIcao, const CAirportIcaoCode &alternateAirportIcao,
                     const QDateTime &takeoffTimePlanned, const QDateTime &takeoffTimeActual, const PhysicalQuantities::CTime &enrouteTime, const PhysicalQuantities::CTime &fuelTime,
                     const CAltitude &cruiseAltitude, const PhysicalQuantities::CSpeed &cruiseTrueAirspeed, FlightRules flightRules, const QString &route, const QString &remarks);
 
         //! Callsign (of aircraft)
         void setCallsign(const CCallsign &callsign);
 
-        //! Set single char ICAO aircraft equipment code like used in "T/A320/F" (here "F")
-        //! \remark function can handle full codes like "T/A320/F" of just the "F"
-        void setEquipmentIcao(const QString &equipmentIcao);
+        //! Set information about the aircraft used in this flightplan
+        void setAircraftInfo(const CFlightPlanAircraftInfo &aircraftInfo);
 
         //! Set origin airport ICAO code
         void setOriginAirportIcao(const QString &originAirportIcao) { m_originAirportIcao = originAirportIcao; }
@@ -360,32 +360,8 @@ namespace BlackMisc::Aviation
         //! Set FP remarks
         void setFlightPlanRemarks(const CFlightPlanRemarks &remarks) { m_remarks = remarks; }
 
-        //! Get ICAO aircraft equipment prefix H/B737/F "H"
-        const QString &getPrefix() const { return m_prefix; }
-
-        //! Set ICAO aircraft equipment prefix H/B737/F "H"
-        void setPrefix(const QString &prefix);
-
-        //! Mark as heavy
-        void setHeavy();
-
-        //! Get ICAO aircraft equipment suffix H/B737/F "F"
-        const QString &getEquipmentSuffix() const { return m_equipmentSuffix; }
-
-        //! Set ICAO aircraft equipment suffix H/B737/F "F"
-        void setEquipmentSuffix(const QString &suffix);
-
-        //! Get aircraft ICAO H/B737/F "B737"
-        const CAircraftIcaoCode &getAircraftIcao() const { return m_aircraftIcao; }
-
-        //! Set aircraft ICAO code H/B737/F "B737"
-        void setAircraftIcao(const CAircraftIcaoCode &icao) { m_aircraftIcao = icao; }
-
-        //! Has aircraft ICAO?
-        bool hasAircraftIcao() const { return m_aircraftIcao.hasDesignator(); }
-
-        //! Full string like "H/B737/F"
-        QString getCombinedPrefixIcaoSuffix() const;
+        //! Get ICAO aircraft NAV/COM equipment
+        CFlightPlanAircraftInfo getAircraftInfo() const { return m_aircraftInfo; }
 
         //! \copydoc BlackMisc::Mixin::Index::propertyByIndex
         QVariant propertyByIndex(CPropertyIndexRef index) const;
@@ -441,42 +417,9 @@ namespace BlackMisc::Aviation
         static bool isIFRRules(const QString &rule);
         //! @}
 
-        //! Get aircraft ICAO code from equipment code like
-        //! \remark we expect something like "H/B772/F" "B773" "B773/F"
-        static QString aircraftIcaoCodeFromEquipmentCode(const QString &equipmentCodeAndAircraft);
-
-        //! Get the 3 parts of "H/B772/F", returned as prefix, ICAO, suffix
-        static QStringList splitEquipmentCode(const QString &equipmentCodeAndAircraft);
-
-        //! Concat the 3 parts to "H/B772/F"
-        static QString concatPrefixIcaoSuffix(const QString &prefix, const QString &icao, const QString &suffix);
-
-        //! Equipment codes 1 character
-        static const QStringList &faaEquipmentCodes();
-
-        //! Codes plus info
-        static const QStringList &faaEquipmentCodesInfo();
-
-        //! SquawkBox equipment codes
-        static const QStringList &squawkBoxEquipmentCodes();
-
-        //! Codes plus info
-        static const QStringList &squawkBoxEquipmentCodesInfo();
-
-        //! All equipment codes
-        static const QStringList &equipmentCodes();
-
-        //! Equipment codes info
-        static const QStringList &equipmentCodesInfo();
-
-        //! Prefix codes "H" .. Heavy, "T" .. TCAS
-        static const QStringList &prefixCodes();
-
     private:
         CCallsign m_callsign; //!< aircraft callsign
-        CAircraftIcaoCode m_aircraftIcao; //!< Aircraft ICAO code
-        QString m_prefix; //!< e.g. "T/A320/F" -> the "T"
-        QString m_equipmentSuffix; //!< e.g. "T/A320/F" -> the "F"
+        CFlightPlanAircraftInfo m_aircraftInfo; //!< Aircraft information
         CAirportIcaoCode m_originAirportIcao;
         CAirportIcaoCode m_destinationAirportIcao;
         CAirportIcaoCode m_alternateAirportIcao;
@@ -497,9 +440,7 @@ namespace BlackMisc::Aviation
         BLACK_METACLASS(
             CFlightPlan,
             // callsign will be current flight
-            BLACK_METAMEMBER(aircraftIcao),
-            BLACK_METAMEMBER(prefix),
-            BLACK_METAMEMBER(equipmentSuffix),
+            BLACK_METAMEMBER(aircraftInfo),
             BLACK_METAMEMBER(originAirportIcao),
             BLACK_METAMEMBER(destinationAirportIcao),
             BLACK_METAMEMBER(alternateAirportIcao),

--- a/src/blackmisc/aviation/flightplanaircraftinfo.cpp
+++ b/src/blackmisc/aviation/flightplanaircraftinfo.cpp
@@ -1,0 +1,388 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#include "flightplanaircraftinfo.h"
+
+BLACK_DEFINE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CFlightPlanAircraftInfo)
+
+namespace BlackMisc::Aviation
+{
+    CFlightPlanAircraftInfo::CFlightPlanAircraftInfo(const CAircraftIcaoCode &aircraftIcao, const CComNavEquipment &comNavEquipment,
+                                                     const CSsrEquipment &ssrEquipment, const CWakeTurbulenceCategory &wtc) : m_aircraftIcao(aircraftIcao),
+                                                                                                                              m_comNavEquipment(comNavEquipment),
+                                                                                                                              m_ssrEquipment(ssrEquipment),
+                                                                                                                              m_wtc(wtc) {}
+
+    CFlightPlanAircraftInfo::CFlightPlanAircraftInfo(QString equipmentCodeAndAircraft)
+    {
+        equipmentCodeAndAircraft = equipmentCodeAndAircraft.trimmed().toUpper().replace(" ", "");
+        const int numberSlash = equipmentCodeAndAircraft.count("/");
+        const int numberHypen = equipmentCodeAndAircraft.count("-");
+        if (numberHypen == 1 && numberSlash == 2)
+        {
+            parseIcaoEquipmentCode(equipmentCodeAndAircraft);
+        }
+        else if (numberSlash >= 1 && numberSlash <= 2 && numberHypen == 0)
+        {
+            parseFaaEquipmentCode(equipmentCodeAndAircraft);
+        }
+        else
+        {
+            parseUnknownEquipmentCode(equipmentCodeAndAircraft);
+        }
+    }
+
+    QString CFlightPlanAircraftInfo::asIcaoString() const
+    {
+        // Avoid returning empty wake turbulence categories and send it to the server.
+        // This can in particular happen when translating from FAA codes to ICAO codes.
+        // This sets a default  wake turbulence category of MEDIUM if the category is unknown otherwise.
+        QChar wtc;
+        if (!m_wtc.isUnknown())
+        {
+            wtc = m_wtc.toQString().at(0);
+        }
+        else
+        {
+            wtc = CWakeTurbulenceCategory(CWakeTurbulenceCategory::MEDIUM).toQString().at(0);
+        }
+
+        return m_aircraftIcao.getDesignator() % "/" % wtc % "-" % m_comNavEquipment.toQString() % "/" % m_ssrEquipment.toQString();
+    }
+
+    QString CFlightPlanAircraftInfo::asFaaString() const
+    {
+        // TCAS prefix (T/) is not used
+        QString s;
+        if (m_wtc.isCategory(CWakeTurbulenceCategory::HEAVY))
+        {
+            s = "H/";
+        }
+        else if (m_wtc.isCategory(CWakeTurbulenceCategory::SUPER))
+        {
+            s = "J/";
+        }
+        s += m_aircraftIcao.getDesignator() % "/" % equipmentToFaaCode(m_comNavEquipment, m_ssrEquipment);
+        return s;
+    }
+
+    CAircraftIcaoCode CFlightPlanAircraftInfo::getAircraftIcao() const
+    {
+        return m_aircraftIcao;
+    }
+
+    CComNavEquipment CFlightPlanAircraftInfo::getComNavEquipment() const
+    {
+        return m_comNavEquipment;
+    }
+
+    CSsrEquipment CFlightPlanAircraftInfo::getSsrEquipment() const
+    {
+        return m_ssrEquipment;
+    }
+
+    CWakeTurbulenceCategory CFlightPlanAircraftInfo::getWtc() const
+    {
+        return m_wtc;
+    }
+
+    QString CFlightPlanAircraftInfo::convertToQString(bool) const
+    {
+        return asIcaoString();
+    }
+
+    void CFlightPlanAircraftInfo::parseIcaoEquipmentCode(const QString &equipment)
+    {
+        // Example: B789/H-SDE1E2E3FGHIJ2J3J4J5M1RWXY/LB1D1
+        QStringList firstSplit = equipment.split("/");
+        Q_ASSERT_X(firstSplit.size() == 3, Q_FUNC_INFO, "Cannot split string as required for the ICAO format");
+        if (!CAircraftIcaoCode::isValidDesignator(firstSplit[0]) || firstSplit[1].isEmpty() || firstSplit[2].isEmpty())
+        {
+            return; // Invalid equipment code, leave everything default initialized
+        }
+
+        m_aircraftIcao = CAircraftIcaoCode(firstSplit[0]);
+
+        try
+        {
+            m_ssrEquipment = CSsrEquipment(firstSplit[2]);
+        }
+        catch (const std::invalid_argument &)
+        {
+            m_ssrEquipment = CSsrEquipment();
+        }
+
+        QStringList secondSplit = firstSplit[1].split("-");
+        if (secondSplit.size() != 2)
+        {
+            return; // Invalid code, leave everything else default initialized
+        }
+
+        if (!secondSplit[0].isEmpty())
+        {
+            try
+            {
+                // if the wake turbulence category incorrectly contains more than one letter
+                // just take the first letter
+                m_wtc = CWakeTurbulenceCategory(secondSplit[0].at(0));
+            }
+            catch (std::invalid_argument &)
+            {
+                m_wtc = CWakeTurbulenceCategory();
+            }
+        }
+        else
+        {
+            m_wtc = CWakeTurbulenceCategory();
+        }
+
+        try
+        {
+            m_comNavEquipment = CComNavEquipment(secondSplit[1]);
+        }
+        catch (std::runtime_error &)
+        {
+            m_comNavEquipment = CComNavEquipment();
+        }
+    }
+
+    void CFlightPlanAircraftInfo::parseFaaEquipmentCode(const QString &equipment)
+    {
+        // Example: H/A346/L
+        QStringList split = equipment.split('/');
+        Q_ASSERT_X(split.size() == 2 || split.size() == 3, Q_FUNC_INFO, "Cannot split string as required for the FAA format");
+        bool missingEquipmentCode = false;
+
+        if (CAircraftIcaoCode::isValidDesignator(split.at(split.size() - 2)))
+        {
+            m_aircraftIcao = CAircraftIcaoCode(split.at(split.size() - 2));
+        }
+        else if (CAircraftIcaoCode::isValidDesignator(split.at(split.size() - 1)))
+        {
+            // the equipment code is missing (like J/A388)
+            m_aircraftIcao = CAircraftIcaoCode(split.at(split.size() - 1));
+            missingEquipmentCode = true;
+        }
+        else
+        {
+            m_aircraftIcao = CAircraftIcaoCode();
+        }
+
+        // Check prefix (wake turbulence category)
+        if (split.length() == 3)
+        {
+            const QString &prefix = split.at(0);
+            if (prefix == "H" || prefix == "J")
+            {
+                m_wtc = CWakeTurbulenceCategory(prefix.at(0));
+            }
+        }
+        else if (split.length() == 2 && split.at(0).size() == 1)
+        {
+            // the equipment code is missing (like J/A388)
+            m_wtc = CWakeTurbulenceCategory(split.at(0).at(0));
+            missingEquipmentCode = true;
+        }
+        else
+        {
+            m_wtc = CWakeTurbulenceCategory();
+        }
+
+        // Equipment Code
+        if (missingEquipmentCode || split.at(split.size() - 1).isEmpty())
+        {
+            return; // No (empty) equipment code
+        }
+
+        // Always taking the first character. If the code contains more than one character, this is likely an error, but we will try it anyway
+        QChar equipmentCode = split.at(split.size() - 1).at(0);
+        auto [comNavEquipment, ssrEquipment] = faaCodeToEquipment(equipmentCode);
+        m_comNavEquipment = comNavEquipment;
+        m_ssrEquipment = ssrEquipment;
+    }
+
+    void CFlightPlanAircraftInfo::parseUnknownEquipmentCode(const QString &equipment)
+    {
+        // likely one part only
+        QStringList split = equipment.split("/");
+        if (split[0].length() > 1 && CAircraftIcaoCode::isValidDesignator(split[0]))
+        {
+            // only ICAO
+            m_aircraftIcao = split[0];
+        }
+        else
+        {
+            // something invalid. Keep default initialized
+        }
+    }
+
+    std::tuple<CComNavEquipment, CSsrEquipment> CFlightPlanAircraftInfo::faaCodeToEquipment(QChar equipmentCode)
+    {
+        CComNavEquipment equip;
+        CSsrEquipment ssr;
+
+        // COM/NAV equipment
+        if (equipmentCode == 'H' || equipmentCode == 'O' || equipmentCode == 'W')
+        {
+            equip = CComNavEquipment({ CComNavEquipment::Rvsm }, {});
+        }
+        else if (equipmentCode == 'Z')
+        {
+            // PBN might not be the correct translation for "RNAV" but we use it to differentiate the codes
+            equip = CComNavEquipment({ CComNavEquipment::Rvsm | CComNavEquipment::Pbn }, {});
+        }
+        else if (equipmentCode == 'L')
+        {
+            equip = CComNavEquipment({ CComNavEquipment::Rvsm | CComNavEquipment::Gnss }, {});
+        }
+        else if (equipmentCode == 'X' || equipmentCode == 'T' || equipmentCode == 'U')
+        {
+            equip = CComNavEquipment({}, {});
+        }
+        else if (equipmentCode == 'D' || equipmentCode == 'B' || equipmentCode == 'A')
+        {
+            equip = CComNavEquipment({ CComNavEquipment::Dme }, {});
+        }
+        else if (equipmentCode == 'M' || equipmentCode == 'N' || equipmentCode == 'P')
+        {
+            equip = CComNavEquipment({ CComNavEquipment::Tacan }, {});
+        }
+        else if (equipmentCode == 'Y' || equipmentCode == 'C' || equipmentCode == 'I')
+        {
+            // PBN might not be the correct translation for "RNAV" but we use it to differentiate the codes
+            equip = CComNavEquipment({ CComNavEquipment::Pbn }, {});
+        }
+        else if (equipmentCode == 'V' || equipmentCode == 'S' || equipmentCode == 'G')
+        {
+            equip = CComNavEquipment({ CComNavEquipment::Gnss }, {});
+        }
+
+        // SSR equipment
+        if (equipmentCode == 'W' || equipmentCode == 'Z' || equipmentCode == 'L' || equipmentCode == 'U' ||
+            equipmentCode == 'A' || equipmentCode == 'P' || equipmentCode == 'I' || equipmentCode == 'G')
+        {
+            ssr = CSsrEquipment::SSrEquipment { CSsrEquipment::ModeAC };
+        }
+        else if (equipmentCode == 'H' || equipmentCode == 'O' || equipmentCode == 'X' || equipmentCode == 'D' ||
+                 equipmentCode == 'M' || equipmentCode == 'Y' || equipmentCode == 'V')
+        {
+            // "O" corresponds to a failed Mode C transponder.
+            // The ICAO format does not contain a separate code for a failed Mode C transponder
+            ssr = CSsrEquipment::SSrEquipment { CSsrEquipment::None };
+        }
+        else if (equipmentCode == 'T' || equipmentCode == 'B' || equipmentCode == 'N' || equipmentCode == 'C' ||
+                 equipmentCode == 'S')
+        {
+            // The ICAO format does not contain a separate code for a general NONE Mode C transponder. We use Mode A instead.
+            ssr = CSsrEquipment::SSrEquipment { CSsrEquipment::ModeA };
+        }
+
+        return { equip, ssr };
+    }
+
+    QChar CFlightPlanAircraftInfo::equipmentToFaaCode(const CComNavEquipment &equip, const CSsrEquipment &ssr)
+    {
+        if (equip.hasEquipment(CComNavEquipment::Rvsm))
+        {
+            if (ssr.hasEquipment(CSsrEquipment::None))
+            {
+                // This could also be 'O' as we cannot differentiate between a failed transponder and a failed Mode C transponder
+                return 'H';
+            }
+
+            // In the following, do not check the transponder capability, as the FAA codes only work with Mode C and not Mode S transponders
+            if (equip.hasEquipment(CComNavEquipment::Gnss))
+            {
+                return 'L';
+            }
+            if (equip.hasEquipment(CComNavEquipment::Pbn))
+            {
+                // PBN is used for RNAV when converting from FAA string to CFlightPlanAircraftInfo
+                return 'Z';
+            }
+            else
+            {
+                return 'W';
+            }
+        }
+        else
+        {
+            if (equip.hasEquipment(CComNavEquipment::Gnss))
+            {
+                if (ssr.hasEquipment(CSsrEquipment::None))
+                {
+                    return 'V';
+                }
+                if (ssr.hasEquipment(CSsrEquipment::ModeAC))
+                {
+                    return 'G';
+                }
+                else
+                {
+                    return 'S';
+                }
+            }
+            if (equip.hasEquipment(CComNavEquipment::Tacan))
+            {
+                if (ssr.hasEquipment(CSsrEquipment::None))
+                {
+                    return 'M';
+                }
+                if (ssr.hasEquipment(CSsrEquipment::ModeAC))
+                {
+                    return 'P';
+                }
+                else
+                {
+                    return 'N';
+                }
+            }
+            if (equip.hasEquipment(CComNavEquipment::Pbn))
+            {
+                // PBN is used for RNAV when converting from FAA string to CFlightPlanAircraftInfo
+                if (ssr.hasEquipment(CSsrEquipment::None))
+                {
+                    return 'Y';
+                }
+                if (ssr.hasEquipment(CSsrEquipment::ModeAC))
+                {
+                    return 'I';
+                }
+                else
+                {
+                    return 'C';
+                }
+            }
+            if (equip.hasEquipment(CComNavEquipment::Dme))
+            {
+                if (ssr.hasEquipment(CSsrEquipment::None))
+                {
+                    return 'D';
+                }
+                if (ssr.hasEquipment(CSsrEquipment::ModeAC))
+                {
+                    return 'A';
+                }
+                else
+                {
+                    return 'B';
+                }
+            }
+
+            // No DME
+            if (ssr.hasEquipment(CSsrEquipment::None))
+            {
+                return 'X';
+            }
+            if (ssr.hasEquipment(CSsrEquipment::ModeAC))
+            {
+                return 'U';
+            }
+            else
+            {
+                return 'T';
+            }
+        }
+    }
+
+}

--- a/src/blackmisc/aviation/flightplanaircraftinfo.h
+++ b/src/blackmisc/aviation/flightplanaircraftinfo.h
@@ -1,0 +1,84 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#ifndef BLACKMISC_AVIATION_FLIGHTPLAN_AIRCRAFT_INFO_H
+#define BLACKMISC_AVIATION_FLIGHTPLAN_AIRCRAFT_INFO_H
+
+#include "blackmisc/blackmiscexport.h"
+#include "blackmisc/valueobject.h"
+#include "blackmisc/aviation/aircrafticaocode.h"
+#include "blackmisc/aviation/comnavequipment.h"
+#include "blackmisc/aviation/ssrequipment.h"
+#include "blackmisc/aviation/waketurbulencecategory.h"
+
+#include <QString>
+
+BLACK_DECLARE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CFlightPlanAircraftInfo)
+
+namespace BlackMisc::Aviation
+{
+    //! Flightplan-related information about an aircraft (aircraft ICAO, equipment and WTC)
+    class BLACKMISC_EXPORT CFlightPlanAircraftInfo : public CValueObject<CFlightPlanAircraftInfo>
+    {
+    public:
+        CFlightPlanAircraftInfo() = default;
+
+        //! Create info from given aircraft ICAO, equipment and wake turbulence category
+        CFlightPlanAircraftInfo(const CAircraftIcaoCode &aircraftIcao, const CComNavEquipment &comNavEquipment,
+                                const CSsrEquipment &ssrEquipment, const CWakeTurbulenceCategory &wtc);
+
+        //! Create aircraft info from a string that contains the 4 parts of an ICAO equipment code (AIRCRAFT_ICAO/WTC-EQUIPMENT/SSR).
+        //! Passing FAA equipment codes like "H/B772/F" is supported as well
+        explicit CFlightPlanAircraftInfo(QString equipmentCodeAndAircraft);
+
+        //! Full string in ICAO format: "AIRCRAFT_ICAO/WTC-EQUIPMENT/SSR"
+        QString asIcaoString() const;
+
+        //! Full string in FAA format: "H/J (if heavy/super)/AIRCRAFT_ICAO/EQUIPMENT-CODE"
+        QString asFaaString() const;
+
+        //! Get Aircraft ICAO
+        CAircraftIcaoCode getAircraftIcao() const;
+
+        //! Get COM/NAV equipment
+        CComNavEquipment getComNavEquipment() const;
+
+        //! Get SSR equipment
+        CSsrEquipment getSsrEquipment() const;
+
+        //! Get Wake Turbulence Category
+        CWakeTurbulenceCategory getWtc() const;
+
+        //! \copydoc BlackMisc::Mixin::String::toQString
+        QString convertToQString(bool i18n = false) const;
+
+        //! Transform single character FAA equipment code to ICAO-based COM/NAV and SSR equipment
+        static std::tuple<CComNavEquipment, CSsrEquipment> faaCodeToEquipment(QChar equipmentCode);
+
+        //! Transform ICAO-based COM/NAV and SSR equipment to a single character FAA equipment code
+        static QChar equipmentToFaaCode(const CComNavEquipment &equip, const CSsrEquipment &ssr);
+
+    private:
+        CAircraftIcaoCode m_aircraftIcao; //!< Aircraft ICAO code
+        CComNavEquipment m_comNavEquipment; //!< COM & NAV equipment (flight plan field 10a)
+        CSsrEquipment m_ssrEquipment; //!< secondary surveillance radar equipment (flight plan field 10b)
+        CWakeTurbulenceCategory m_wtc; //!< wake turbulence category. This information is also part of m_aircraftIcao, but is not always filled.
+
+        void parseIcaoEquipmentCode(const QString &equipment); //!< Initialize members from ICAO format equipment codes
+        void parseFaaEquipmentCode(const QString &equipment); //!< Initialize members from FAA format equipment codes
+        void parseUnknownEquipmentCode(const QString &equipment); //!< Initialize members from unknown format equipment strings (best guesses)
+
+        BLACK_METACLASS(
+            CFlightPlanAircraftInfo,
+            BLACK_METAMEMBER(aircraftIcao),
+            BLACK_METAMEMBER(comNavEquipment),
+            BLACK_METAMEMBER(ssrEquipment),
+            BLACK_METAMEMBER(wtc)
+        );
+    };
+
+}
+
+Q_DECLARE_METATYPE(BlackMisc::Aviation::CFlightPlanAircraftInfo)
+
+#endif // BLACKMISC_AVIATION_FLIGHTPLAN_AIRCRAFT_INFO_H

--- a/src/blackmisc/aviation/registermetadataaviation.cpp
+++ b/src/blackmisc/aviation/registermetadataaviation.cpp
@@ -70,8 +70,11 @@ namespace BlackMisc
             CCallsign::registerMetadata();
             CCallsignSet::registerMetadata();
             CComSystem::registerMetadata();
+            CSsrEquipment::registerMetadata();
+            CComNavEquipment::registerMetadata();
             CWakeTurbulenceCategory::registerMetadata();
             CFlightPlan::registerMetadata();
+            CFlightPlanAircraftInfo::registerMetadata();
             CFlightPlanList::registerMetadata();
             CSimBriefData::registerMetadata();
             CFlightPlanRemarks::registerMetadata();

--- a/src/blackmisc/aviation/registermetadataaviation.cpp
+++ b/src/blackmisc/aviation/registermetadataaviation.cpp
@@ -70,6 +70,7 @@ namespace BlackMisc
             CCallsign::registerMetadata();
             CCallsignSet::registerMetadata();
             CComSystem::registerMetadata();
+            CWakeTurbulenceCategory::registerMetadata();
             CFlightPlan::registerMetadata();
             CFlightPlanList::registerMetadata();
             CSimBriefData::registerMetadata();

--- a/src/blackmisc/aviation/ssrequipment.cpp
+++ b/src/blackmisc/aviation/ssrequipment.cpp
@@ -1,0 +1,203 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#include "ssrequipment.h"
+
+BLACK_DEFINE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CSsrEquipment)
+
+namespace BlackMisc::Aviation
+{
+    CSsrEquipment::CSsrEquipment(SSrEquipment equipment) : m_equipment(equipment)
+    {
+        if (m_equipment == SSrEquipment())
+        {
+            m_equipment = None;
+        }
+    }
+
+    CSsrEquipment::CSsrEquipment(QString equipment)
+    {
+
+        if (equipment.isEmpty())
+        {
+            return;
+        }
+
+        m_equipment = {}; // Clear default flag
+
+        auto append_equipment_flag_if_exist = [&equipment, this](SsrEquipmentOption flag) {
+            QString str = flagToString(flag);
+            if (equipment.contains(str))
+            {
+                equipment = equipment.remove(str);
+                m_equipment |= flag;
+            }
+        };
+
+        append_equipment_flag_if_exist(None);
+        append_equipment_flag_if_exist(ModeA);
+        append_equipment_flag_if_exist(ModeAC);
+        append_equipment_flag_if_exist(ModeSTypeE);
+        append_equipment_flag_if_exist(ModeSTypeH);
+        append_equipment_flag_if_exist(ModeSTypeI);
+        append_equipment_flag_if_exist(ModeSTypeL);
+        append_equipment_flag_if_exist(ModeSTypeX);
+        append_equipment_flag_if_exist(ModeSTypeP);
+        append_equipment_flag_if_exist(ModeSTypeS);
+        append_equipment_flag_if_exist(AdsBB1);
+        append_equipment_flag_if_exist(AdsBB2);
+        append_equipment_flag_if_exist(AdsBU1);
+        append_equipment_flag_if_exist(AdsBU2);
+        append_equipment_flag_if_exist(AdsBV1);
+        append_equipment_flag_if_exist(AdsBV2);
+        append_equipment_flag_if_exist(AdsCD1);
+        append_equipment_flag_if_exist(AdsCG1);
+
+        if (!equipment.isEmpty() && m_equipment == SSrEquipment())
+        {
+            // Default if nothing correct is provided
+            m_equipment = None;
+        }
+    }
+
+    QStringList CSsrEquipment::enabledOptions() const
+    {
+        QStringList list;
+
+        // Append flag (as string) to list if flag exists in current equipment
+        auto append_flag_if_exist = [&list, this](SsrEquipmentOption flag) {
+            if (m_equipment.testFlag(flag)) list << flagToString(flag);
+        };
+
+        append_flag_if_exist(None);
+        append_flag_if_exist(ModeA);
+        append_flag_if_exist(ModeAC);
+        append_flag_if_exist(ModeSTypeE);
+        append_flag_if_exist(ModeSTypeH);
+        append_flag_if_exist(ModeSTypeI);
+        append_flag_if_exist(ModeSTypeL);
+        append_flag_if_exist(ModeSTypeX);
+        append_flag_if_exist(ModeSTypeP);
+        append_flag_if_exist(ModeSTypeS);
+        append_flag_if_exist(AdsBB1);
+        append_flag_if_exist(AdsBB2);
+        append_flag_if_exist(AdsBU1);
+        append_flag_if_exist(AdsBU2);
+        append_flag_if_exist(AdsBV1);
+        append_flag_if_exist(AdsBV2);
+        append_flag_if_exist(AdsCD1);
+        append_flag_if_exist(AdsCG1);
+
+        return list;
+    }
+
+    QString CSsrEquipment::convertToQString(bool) const
+    {
+        const QString equipmentString = enabledOptions().join("");
+        Q_ASSERT_X(!equipmentString.isEmpty(), Q_FUNC_INFO, "Equipment string should not be empty");
+        return equipmentString;
+    }
+
+    QString CSsrEquipment::flagToString(CSsrEquipment::SSrEquipment flag)
+    {
+        if (flag == None)
+        {
+            static const QString q("N");
+            return q;
+        }
+        if (flag == ModeA)
+        {
+            static const QString q("A");
+            return q;
+        }
+        if (flag == ModeAC)
+        {
+            static const QString q("C");
+            return q;
+        }
+        if (flag == ModeSTypeE)
+        {
+            static const QString q("E");
+            return q;
+        }
+        if (flag == ModeSTypeH)
+        {
+            static const QString q("H");
+            return q;
+        }
+        if (flag == ModeSTypeI)
+        {
+            static const QString q("I");
+            return q;
+        }
+        if (flag == ModeSTypeL)
+        {
+            static const QString q("L");
+            return q;
+        }
+        if (flag == ModeSTypeX)
+        {
+            static const QString q("X");
+            return q;
+        }
+        if (flag == ModeSTypeP)
+        {
+            static const QString q("P");
+            return q;
+        }
+        if (flag == ModeSTypeS)
+        {
+            static const QString q("S");
+            return q;
+        }
+        if (flag == AdsBB1)
+        {
+            static const QString q("B1");
+            return q;
+        }
+        if (flag == AdsBB2)
+        {
+            static const QString q("B2");
+            return q;
+        }
+        if (flag == AdsBU1)
+        {
+            static const QString q("U1");
+            return q;
+        }
+        if (flag == AdsBU2)
+        {
+            static const QString q("U2");
+            return q;
+        }
+        if (flag == AdsBV1)
+        {
+            static const QString q("V1");
+            return q;
+        }
+        if (flag == AdsBV2)
+        {
+            static const QString q("V2");
+            return q;
+        }
+        if (flag == AdsCD1)
+        {
+            static const QString q("D1");
+            return q;
+        }
+        if (flag == AdsCG1)
+        {
+            static const QString q("G1");
+            return q;
+        }
+        return {};
+    }
+
+    QStringList CSsrEquipment::allEquipmentLetters()
+    {
+        // In order as they appear in the final string
+        static const QStringList r({ "N", "A", "C", "E", "H", "I", "L", "X", "P", "S", "B1", "B2", "U1", "U2", "V1", "V2", "D1", "G1" });
+        return r;
+    }
+
+}

--- a/src/blackmisc/aviation/ssrequipment.h
+++ b/src/blackmisc/aviation/ssrequipment.h
@@ -1,0 +1,79 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#ifndef BLACKMISC_AVIATION_SSREQUIPMENT_H
+#define BLACKMISC_AVIATION_SSREQUIPMENT_H
+
+#include "blackmisc/blackmiscexport.h"
+#include "blackmisc/valueobject.h"
+
+BLACK_DECLARE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CSsrEquipment)
+
+namespace BlackMisc::Aviation
+{
+    //! ICAO flightplan field 10b
+    class BLACKMISC_EXPORT CSsrEquipment : public BlackMisc::CValueObject<CSsrEquipment>
+    {
+    public:
+        enum SsrEquipmentOption : int
+        {
+            None = (1 << 0),
+            ModeA = (1 << 1),
+            ModeAC = (1 << 2),
+            ModeSTypeE = (1 << 3),
+            ModeSTypeH = (1 << 4),
+            ModeSTypeI = (1 << 5),
+            ModeSTypeL = (1 << 6),
+            ModeSTypeX = (1 << 7),
+            ModeSTypeP = (1 << 8),
+            ModeSTypeS = (1 << 9),
+            AdsBB1 = (1 << 10),
+            AdsBB2 = (1 << 11),
+            AdsBU1 = (1 << 12),
+            AdsBU2 = (1 << 13),
+            AdsBV1 = (1 << 14),
+            AdsBV2 = (1 << 15),
+            AdsCD1 = (1 << 16),
+            AdsCG1 = (1 << 17)
+        };
+
+        Q_DECLARE_FLAGS(SSrEquipment, SsrEquipmentOption);
+
+        //! Create default SSR equipment with "None" equipment enabled
+        CSsrEquipment() = default;
+
+        //! Create object with given equipment
+        CSsrEquipment(SSrEquipment equipment);
+
+        //! Create object from an ICAO SSR equipment string (for example "LB1")
+        explicit CSsrEquipment(QString equipment);
+
+        //! Get all possible SSR equipment code letters
+        static QStringList allEquipmentLetters();
+
+        //! Get all enabled SSR equipment codes of this object as a list
+        QStringList enabledOptions() const;
+
+        //! Get the SSR equipment string of this object (for example "LB1")
+        QString convertToQString(bool i18n = false) const;
+
+        //! Does this object contains \p equip?
+        bool hasEquipment(SsrEquipmentOption equip) const { return m_equipment.testFlag(equip); }
+
+    private:
+        //! Get the string for the specific SSR equipment
+        static QString flagToString(SSrEquipment flag);
+
+        SSrEquipment m_equipment = None;
+
+        BLACK_METACLASS(
+            CSsrEquipment,
+            BLACK_METAMEMBER(equipment)
+        );
+    };
+
+}
+
+Q_DECLARE_METATYPE(BlackMisc::Aviation::CSsrEquipment)
+
+#endif // BLACKMISC_AVIATION_SSREQUIPMENT_H

--- a/src/blackmisc/aviation/waketurbulencecategory.cpp
+++ b/src/blackmisc/aviation/waketurbulencecategory.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#include "waketurbulencecategory.h"
+
+BLACK_DEFINE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CWakeTurbulenceCategory)
+
+namespace BlackMisc::Aviation
+{
+    CWakeTurbulenceCategory::CWakeTurbulenceCategory(WakeTurbulenceCategory wtc) : m_wtc(wtc)
+    {
+    }
+
+    CWakeTurbulenceCategory::CWakeTurbulenceCategory(QChar letter)
+    {
+        letter = letter.toUpper();
+        if (letter == 'L')
+        {
+            m_wtc = LIGHT;
+        }
+        else if (letter == 'M')
+        {
+            m_wtc = MEDIUM;
+        }
+        else if (letter == 'H')
+        {
+            m_wtc = HEAVY;
+        }
+        else if (letter == 'J')
+        {
+            m_wtc = SUPER;
+        }
+        else
+        {
+            // This includes "-" which is used in the database for aircraft with unknown wake turbulence category
+            m_wtc = UNKNOWN;
+        }
+    }
+
+    QString CWakeTurbulenceCategory::convertToQString(bool) const
+    {
+        switch (m_wtc)
+        {
+        case WakeTurbulenceCategory::LIGHT: return QStringLiteral("L");
+        case WakeTurbulenceCategory::MEDIUM: return QStringLiteral("M");
+        case WakeTurbulenceCategory::HEAVY: return QStringLiteral("H");
+        case WakeTurbulenceCategory::SUPER: return QStringLiteral("J");
+        default: [[fallthrough]];
+        case WakeTurbulenceCategory::UNKNOWN: return QStringLiteral("-");
+        }
+    }
+}

--- a/src/blackmisc/aviation/waketurbulencecategory.h
+++ b/src/blackmisc/aviation/waketurbulencecategory.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+#ifndef BLACKMISC_AVIATION_WAKETURBULENCECATEGORY_H
+#define BLACKMISC_AVIATION_WAKETURBULENCECATEGORY_H
+
+#include "blackmisc/valueobject.h"
+#include "blackmisc/blackmiscexport.h"
+
+#include <QString>
+#include <QtGlobal>
+
+BLACK_DECLARE_VALUEOBJECT_MIXINS(BlackMisc::Aviation, CWakeTurbulenceCategory)
+
+namespace BlackMisc::Aviation
+{
+    class BLACKMISC_EXPORT CWakeTurbulenceCategory : public CValueObject<CWakeTurbulenceCategory>
+    {
+    public:
+        //! ICAO wake turbulence categories
+        enum WakeTurbulenceCategory
+        {
+            UNKNOWN, // required when converting from FAA equipment codes and for some database entries where the correct WTC is not available
+            LIGHT,
+            MEDIUM,
+            HEAVY,
+            SUPER
+        };
+
+        //! Create default object with unknown wake turbulence category
+        CWakeTurbulenceCategory() = default;
+
+        //! Create object with given wake turbulence category
+        CWakeTurbulenceCategory(WakeTurbulenceCategory wtc);
+
+        //! Create object from single wake turbulence category letter
+        explicit CWakeTurbulenceCategory(QChar letter);
+
+        //! \copydoc BlackMisc::Mixin::String::toQString
+        QString convertToQString(bool i18n = false) const;
+
+        //! Is the wake turbulence category unknown?
+        bool isUnknown() const { return m_wtc == UNKNOWN; }
+
+        //! Is the wake turbulence category of this object the same as \p category?
+        bool isCategory(WakeTurbulenceCategory category) const { return m_wtc == category; }
+
+    private:
+        WakeTurbulenceCategory m_wtc = UNKNOWN;
+
+        BLACK_METACLASS(
+            CWakeTurbulenceCategory,
+            BLACK_METAMEMBER(wtc)
+        );
+    };
+
+}
+
+Q_DECLARE_METATYPE(BlackMisc::Aviation::CWakeTurbulenceCategory)
+
+#endif // BLACKMISC_AVIATION_WAKETURBULENCECATEGORY_H

--- a/src/blackmisc/blackmisc.qrc
+++ b/src/blackmisc/blackmisc.qrc
@@ -125,6 +125,7 @@
         <file>icons/pastel/16/folder-pink.png</file>
         <file>icons/pastel/16/folder-purple.png</file>
         <file>icons/pastel/16/undo.png</file>
+        <file>icons/pastel/16/pencil.png</file>
     </qresource>
     <qresource prefix="/vatsim">
         <file>icons/vatsim/C1.png</file>

--- a/src/blackmisc/network/fsdsetup.cpp
+++ b/src/blackmisc/network/fsdsetup.cpp
@@ -37,7 +37,7 @@ namespace BlackMisc::Network
 
     QString CFsdSetup::sendReceiveDetailsToString(SendReceiveDetails details)
     {
-        static const QString ds("Send parts; %1 gnd: %2 interim: %3 Receive parts: %4 gnd: %5 interim: %6 3letter: %7");
+        static const QString ds("Send parts; %1 gnd: %2 interim: %3 Receive parts: %4 gnd: %5 interim: %6 3letter: %7 ICAO equipment %8");
         return ds.arg(boolToYesNo(details.testFlag(SendAircraftParts)),
                       boolToYesNo(details.testFlag(SendGndFlag)),
                       boolToYesNo(details.testFlag(SendInterimPositions)),
@@ -45,10 +45,11 @@ namespace BlackMisc::Network
                       boolToYesNo(details.testFlag(ReceiveAircraftParts)),
                       boolToYesNo(details.testFlag(ReceiveGndFlag)),
                       boolToYesNo(details.testFlag(ReceiveInterimPositions)),
-                      boolToYesNo(details.testFlag(Force3LetterAirlineICAO)));
+                      boolToYesNo(details.testFlag(Force3LetterAirlineICAO)),
+                      boolToYesNo(details.testFlag(SendFplWithIcaoEquipment)));
     }
 
-    void CFsdSetup::setSendReceiveDetails(bool partsSend, bool partsReceive, bool gndSend, bool gndReceive, bool interimSend, bool interimReceive, bool visualSend, bool euroscopeSimDataReceive)
+    void CFsdSetup::setSendReceiveDetails(bool partsSend, bool partsReceive, bool gndSend, bool gndReceive, bool interimSend, bool interimReceive, bool visualSend, bool euroscopeSimDataReceive, bool icaoEquipment)
     {
         SendReceiveDetails s = Nothing;
         if (partsSend) { s |= SendAircraftParts; }
@@ -59,6 +60,7 @@ namespace BlackMisc::Network
         if (interimReceive) { s |= ReceiveInterimPositions; }
         if (visualSend) { s |= SendVisualPositions; }
         if (euroscopeSimDataReceive) { s |= ReceiveEuroscopeSimData; }
+        if (icaoEquipment) { s |= SendFplWithIcaoEquipment; }
         this->setSendReceiveDetails(s);
     }
 

--- a/src/blackmisc/network/fsdsetup.h
+++ b/src/blackmisc/network/fsdsetup.h
@@ -43,6 +43,7 @@ namespace BlackMisc::Network
             Force3LetterAirlineICAO = 1 << 6, //!< force 3 letter airline ICAO code
             SendVisualPositions = 1 << 7, //!< visual positions out
             ReceiveEuroscopeSimData = 1 << 8, //!< euroscope SIMDATA in
+            SendFplWithIcaoEquipment = 1 << 9, //!< send flightplan with ICAO equipment code instead of FAA code
             AllSending = SendAircraftParts | SendInterimPositions | SendVisualPositions | SendGndFlag, //!< all out
             AllReceive = ReceiveAircraftParts | ReceiveInterimPositions | ReceiveGndFlag, //!< all in
             All = AllReceive | AllSending, //!< all
@@ -51,7 +52,7 @@ namespace BlackMisc::Network
             AllReceiveWithoutGnd = AllReceive - ReceiveGndFlag, //!< all in, but no gnd.flag
             AllInterimPositions = SendInterimPositions | ReceiveInterimPositions, //!< all interim positions
             AllWithoutGnd = AllReceiveWithoutGnd | AllSendingWithoutGnd, //!< all, but no gnd.flag
-            VATSIMDefault = AllParts | Force3LetterAirlineICAO | SendVisualPositions
+            VATSIMDefault = AllParts | Force3LetterAirlineICAO | SendVisualPositions | SendFplWithIcaoEquipment
         };
         Q_DECLARE_FLAGS(SendReceiveDetails, SendReceiveDetailsFlag)
 
@@ -90,7 +91,7 @@ namespace BlackMisc::Network
         void removeSendReceiveDetails(SendReceiveDetails sendReceive) { m_sendReceive &= ~sendReceive; }
 
         //! Set send / receive details
-        void setSendReceiveDetails(bool partsSend, bool partsReceive, bool gndSend, bool gndReceive, bool interimSend, bool interimReceive, bool visualSend, bool euroscopeSimDataReceive);
+        void setSendReceiveDetails(bool partsSend, bool partsReceive, bool gndSend, bool gndReceive, bool interimSend, bool interimReceive, bool visualSend, bool euroscopeSimDataReceive, bool icaoEquipment);
 
         //! @{
         //! FSD setup flags
@@ -103,6 +104,7 @@ namespace BlackMisc::Network
         bool receiveGndFlag() const { return this->getSendReceiveDetails().testFlag(ReceiveGndFlag); }
         bool receiveInterimPositions() const { return this->getSendReceiveDetails().testFlag(ReceiveInterimPositions); }
         bool receiveEuroscopeSimData() const { return this->getSendReceiveDetails().testFlag(ReceiveEuroscopeSimData); }
+        bool shouldSendFlightPlanEquipmentInIcaoFormat() const { return this->getSendReceiveDetails().testFlag(SendFplWithIcaoEquipment); }
         //! @}
 
         //! @{

--- a/src/blackmisc/network/server.cpp
+++ b/src/blackmisc/network/server.cpp
@@ -54,19 +54,6 @@ namespace BlackMisc::Network
         return QStringLiteral("%1 %2 %3:%4 %5 %6 accepting: %7 FSD: %8 con.since: %9").arg(m_name, m_description, m_address).arg(m_port).arg(m_user.toQString(i18n), m_ecosystem.getSystemString(), boolToYesNo(m_isAcceptingConnections), m_fsdSetup.toQString(i18n), this->isConnected() ? this->getFormattedUtcTimestampHms() : "not con.");
     }
 
-    const CServer &CServer::swiftFsdTestServer(bool withPw)
-    {
-        // CUser("guest", "Guest Client project", "", "guest")
-        // PW!!!!! => use CObfuscation::endocde to get the strings
-        static const CServer dvp("Testserver", "Client project testserver", "fsd.swift-project.org", 6809,
-                                 CUser("OBF:AwJ6BweZqpmtmORL", "OBF:AwI/594lQTJGZnmSwB0=", "", "OBF:AwKi3JkHNAczBno="),
-                                 CFsdSetup(), CVoiceSetup(), CEcosystem(CEcosystem::swiftTest()), CServer::FSDServerVatsim);
-        static const CServer dvnWithPw("Testserver", "Client project testserver", "fsd.swift-project.org", 6809,
-                                       CUser("OBF:AwJ6BweZqpmtmORL", "OBF:AwI/594lQTJGZnmSwB0=", "", ""),
-                                       CFsdSetup(), CVoiceSetup(), CEcosystem(CEcosystem::swiftTest()), CServer::FSDServerVatsim);
-        return withPw ? dvp : dvnWithPw;
-    }
-
     const CServer &CServer::fscFsdServer()
     {
         static const CServer fsc = [] {

--- a/src/blackmisc/network/server.h
+++ b/src/blackmisc/network/server.h
@@ -208,9 +208,6 @@ namespace BlackMisc::Network
         //! \copydoc BlackMisc::Mixin::String::toQString()
         QString convertToQString(bool i18n = false) const;
 
-        //! swift FSD test server
-        static const CServer &swiftFsdTestServer(bool withPw = false);
-
         //! FSC server
         static const CServer &fscFsdServer();
 

--- a/src/blackmisc/network/settings/serversettings.h
+++ b/src/blackmisc/network/settings/serversettings.h
@@ -46,7 +46,7 @@ namespace BlackMisc::Network::Settings
         //! \copydoc BlackMisc::TSettingTrait::defaultValue
         static const BlackMisc::Network::CServer &defaultValue()
         {
-            static const CServer dv = CServer::swiftFsdTestServer();
+            static const CServer dv;
             return dv;
         }
     };

--- a/src/blackmisc/network/url.cpp
+++ b/src/blackmisc/network/url.cpp
@@ -102,6 +102,16 @@ namespace BlackMisc::Network
         this->appendQuery(key + "=" + value);
     }
 
+    bool CUrl::hasFragment() const
+    {
+        return !m_fragment.isEmpty();
+    }
+
+    void CUrl::setFragment(const QString &fragment)
+    {
+        m_fragment = fragment;
+    }
+
     QString CUrl::getFullUrl(bool withQuery) const
     {
         if (m_host.isEmpty()) { return {}; }
@@ -109,6 +119,7 @@ namespace BlackMisc::Network
         QString qn(m_host);
         if (!hasDefaultPort() && hasPort()) { qn = qn.append(":").append(QString::number(m_port)); }
         if (hasPath()) { qn = qn.append("/").append(m_path).replace("//", "/"); }
+        if (hasFragment()) { qn = qn.append("#").append(m_fragment).replace("//", "/"); }
         if (hasQuery() && withQuery) { qn = qn.append("?").append(m_query); }
         if (hasScheme()) { qn = QString(this->getScheme()).append("://").append(qn); }
         return qn;
@@ -136,6 +147,7 @@ namespace BlackMisc::Network
         this->setScheme(url.scheme());
         this->setPath(url.path());
         this->setQuery(url.query());
+        this->setFragment(url.fragment());
     }
 
     QNetworkRequest CUrl::toNetworkRequest() const

--- a/src/blackmisc/network/url.h
+++ b/src/blackmisc/network/url.h
@@ -22,7 +22,7 @@ BLACK_DECLARE_VALUEOBJECT_MIXINS(BlackMisc::Network, CUrl)
 namespace BlackMisc::Network
 {
     //! Value object encapsulating information of a location,
-    //! kind of simplied CValueObject compliant version of QUrl
+    //! kind of simplified CValueObject compliant version of QUrl
     class BLACKMISC_EXPORT CUrl : public CValueObject<CUrl>
     {
     public:
@@ -104,6 +104,12 @@ namespace BlackMisc::Network
 
         //! Append query
         void appendQuery(const QString &key, const QString &value);
+
+        //! Fragment string?
+        bool hasFragment() const;
+
+        //! Set fragment
+        void setFragment(const QString &fragment);
 
         //! Empty
         bool isEmpty() const;
@@ -194,6 +200,7 @@ namespace BlackMisc::Network
         int m_port = -1;
         QString m_path;
         QString m_query;
+        QString m_fragment;
 
         static QString stripQueryString(const QString &query);
 
@@ -203,7 +210,8 @@ namespace BlackMisc::Network
             BLACK_METAMEMBER(host),
             BLACK_METAMEMBER(port),
             BLACK_METAMEMBER(path),
-            BLACK_METAMEMBER(query)
+            BLACK_METAMEMBER(query),
+            BLACK_METAMEMBER(fragment)
         );
     };
 } // namespace

--- a/src/blackmisc/simulation/aircraftmodellist.cpp
+++ b/src/blackmisc/simulation/aircraftmodellist.cpp
@@ -316,7 +316,7 @@ namespace BlackMisc::Simulation
     {
         const CAircraftModelList ml = this->findByCombinedType(combinedType);
         if (ml.isEmpty()) { return ml; }
-        const QString wtcUc(wtc.toUpper().trimmed());
+        const CWakeTurbulenceCategory wtcUc = wtc.isEmpty() ? CWakeTurbulenceCategory() : CWakeTurbulenceCategory(wtc.toUpper().trimmed().at(0));
         return this->findBy([&](const CAircraftModel &model) {
             const CAircraftIcaoCode icao(model.getAircraftIcaoCode());
             return icao.getWtc() == wtcUc;

--- a/src/blackmisc/test/testdata.cpp
+++ b/src/blackmisc/test/testdata.cpp
@@ -77,8 +77,9 @@ namespace BlackMisc::Test
 
     const CFlightPlan &CTestData::getFlightPlan()
     {
+        static const CFlightPlanAircraftInfo info("T/A320/F");
         static const CFlightPlan fp(CCallsign("DAMBZ", CCallsign::Aircraft),
-                                    "T/A320/F", "EDDF", "EDDM", "EDDN",
+                                    info, "EDDF", "EDDM", "EDDN",
                                     QDateTime::currentDateTimeUtc(), QDateTime::currentDateTime().addSecs(600),
                                     CTime(1.0, CTimeUnit::h()), CTime(2.0, CTimeUnit::h()),
                                     CAltitude(10000, CAltitude::MeanSeaLevel, CLengthUnit::ft()), CSpeed(400, CSpeedUnit::kts()), CFlightPlan::IFR,

--- a/tests/blackcore/fsd/testfsdclient/testfsdclient.cpp
+++ b/tests/blackcore/fsd/testfsdclient/testfsdclient.cpp
@@ -26,6 +26,7 @@
 
 using namespace BlackMisc;
 using namespace BlackMisc::Aviation;
+using namespace BlackMisc::Audio;
 using namespace BlackMisc::Geo;
 using namespace BlackMisc::PhysicalQuantities;
 using namespace BlackMisc::Network;
@@ -101,6 +102,8 @@ namespace BlackFsdTest
 
     private:
         CFSDClient *m_client = nullptr;
+
+        const CServer &localTestServer();
     };
 
     void CTestFSDClient::initTestCase()
@@ -108,9 +111,17 @@ namespace BlackFsdTest
         BlackMisc::registerMetadata();
     }
 
+    const CServer &CTestFSDClient::localTestServer()
+    {
+        static const CServer dvp("Testserver", "Client project testserver", "localhost", 6809,
+                                 CUser("1234567", "Test User", "", "123456"),
+                                 CFsdSetup(), CVoiceSetup(), CEcosystem(CEcosystem::swiftTest()), CServer::FSDServerVatsim);
+        return dvp;
+    }
+
     void CTestFSDClient::init()
     {
-        const CServer server = CServer::swiftFsdTestServer(true);
+        const CServer server = localTestServer();
 
         COwnAircraftProviderDummy::instance()->updateOwnCallsign("ABCD");
         CLivery livery;
@@ -841,7 +852,7 @@ namespace BlackFsdTest
 
     //    void CTestFSDClient::testConnection()
     //    {
-    //        const CServer fsdServer = CServer::swiftFsdTestServer(true);
+    //        const CServer fsdServer = localTestServer();
     //        if (!pingServer(fsdServer)) { QSKIP("Server not reachable."); }
     //
     //        QSignalSpy spy(m_client, &CFSDClient::connectionStatusChanged);

--- a/tests/blackmisc/CMakeLists.txt
+++ b/tests/blackmisc/CMakeLists.txt
@@ -30,6 +30,12 @@ add_swift_test(
         LINK_LIBRARIES misc tests_test Qt::Core
 )
 
+add_swift_test(
+        NAME misc_aviation_flightplanaircraftinfo
+        SOURCES aviation/testflightplan/testflightplanaircraftinfo.cpp
+        LINK_LIBRARIES misc tests_test Qt::Core
+)
+
 ##############
 ##    Geo   ##
 ##############

--- a/tests/blackmisc/aviation/testaviation/testaviation.cpp
+++ b/tests/blackmisc/aviation/testaviation/testaviation.cpp
@@ -35,6 +35,7 @@
 #include <QTest>
 
 using namespace BlackMisc::Aviation;
+using namespace BlackMisc::Audio;
 using namespace BlackMisc::PhysicalQuantities;
 using namespace BlackMisc::Network;
 using namespace BlackMisc::Geo;
@@ -308,7 +309,9 @@ namespace BlackMiscTest
         const CUser user2(user1);
         QVERIFY2(user1 == user2, "information shall be equal");
 
-        const CServer server1 = CServer::swiftFsdTestServer();
+        const CServer server1 = CServer("Testserver", "Client project testserver", "localhost", 6809,
+                                        CUser("111111", "My Name", "", "123"),
+                                        CFsdSetup(), CVoiceSetup(), CEcosystem(CEcosystem::swiftTest()), CServer::FSDServerVatsim);
         const CServer server2(server1);
         QVERIFY2(server1 == server2, "server shall be equal");
 

--- a/tests/blackmisc/aviation/testaviation/testaviation.cpp
+++ b/tests/blackmisc/aviation/testaviation/testaviation.cpp
@@ -17,6 +17,7 @@
 #include "blackmisc/aviation/informationmessage.h"
 #include "blackmisc/aviation/navsystem.h"
 #include "blackmisc/aviation/transponder.h"
+#include "blackmisc/aviation/waketurbulencecategory.h"
 #include "blackmisc/mixin/mixincompare.h"
 #include "blackmisc/geo/coordinategeodetic.h"
 #include "blackmisc/geo/latitude.h"
@@ -74,6 +75,9 @@ namespace BlackMiscTest
 
         //! Test some of the guessing functions
         void testGuessing();
+
+        //! Test wake turbulence categories
+        void testWakeTurbulenceCategories();
     };
 
     void CTestAviation::headingBasics()
@@ -378,6 +382,60 @@ namespace BlackMiscTest
 
         QVERIFY(s172 < sB747);
         QVERIFY(sB737 < sB747);
+    }
+
+    void CTestAviation::testWakeTurbulenceCategories()
+    {
+        const CWakeTurbulenceCategory catLight1('L');
+        const CWakeTurbulenceCategory catLight2('l');
+        const CWakeTurbulenceCategory catLight3(CWakeTurbulenceCategory::LIGHT);
+
+        const CWakeTurbulenceCategory catMedium1('M');
+        const CWakeTurbulenceCategory catMedium2('m');
+        const CWakeTurbulenceCategory catMedium3(CWakeTurbulenceCategory::MEDIUM);
+
+        const CWakeTurbulenceCategory catHeavy1('H');
+        const CWakeTurbulenceCategory catHeavy2('h');
+        const CWakeTurbulenceCategory catHeavy3(CWakeTurbulenceCategory::HEAVY);
+
+        const CWakeTurbulenceCategory catSuper1('J');
+        const CWakeTurbulenceCategory catSuper2('j');
+        const CWakeTurbulenceCategory catSuper3(CWakeTurbulenceCategory::SUPER);
+
+        const CWakeTurbulenceCategory catUnknown1('-');
+        const CWakeTurbulenceCategory catUnknown2('A');
+        const CWakeTurbulenceCategory catUnknown3('x');
+        const CWakeTurbulenceCategory catUnknown4(CWakeTurbulenceCategory::UNKNOWN);
+
+        QVERIFY(catLight1.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::LIGHT));
+        QVERIFY(catLight2.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::LIGHT));
+        QVERIFY(catLight3.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::LIGHT));
+        QCOMPARE(catLight1.toQString(), "L");
+
+        QVERIFY(catMedium1.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::MEDIUM));
+        QVERIFY(catMedium2.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::MEDIUM));
+        QVERIFY(catMedium3.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::MEDIUM));
+        QCOMPARE(catMedium1.toQString(), "M");
+
+        QVERIFY(catHeavy1.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::HEAVY));
+        QVERIFY(catHeavy2.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::HEAVY));
+        QVERIFY(catHeavy3.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::HEAVY));
+        QCOMPARE(catHeavy1.toQString(), "H");
+
+        QVERIFY(catSuper1.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::SUPER));
+        QVERIFY(catSuper2.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::SUPER));
+        QVERIFY(catSuper3.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::SUPER));
+        QCOMPARE(catSuper1.toQString(), "J");
+
+        QVERIFY(catUnknown1.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::UNKNOWN));
+        QVERIFY(catUnknown1.isUnknown());
+        QVERIFY(catUnknown2.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::UNKNOWN));
+        QVERIFY(catUnknown2.isUnknown());
+        QVERIFY(catUnknown3.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::UNKNOWN));
+        QVERIFY(catUnknown3.isUnknown());
+        QVERIFY(catUnknown4.isCategory(BlackMisc::Aviation::CWakeTurbulenceCategory::UNKNOWN));
+        QVERIFY(catUnknown4.isUnknown());
+        QCOMPARE(catUnknown1.toQString(), "-");
     }
 
 } // namespace

--- a/tests/blackmisc/aviation/testflightplan/testflightplanaircraftinfo.cpp
+++ b/tests/blackmisc/aviation/testflightplan/testflightplanaircraftinfo.cpp
@@ -1,0 +1,229 @@
+//  SPDX-FileCopyrightText: Copyright (C) swift Project Community / Contributors
+//  SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-swift-pilot-client-1
+
+//! \cond PRIVATE_TESTS
+//! \file
+//! \ingroup testblackmisc
+
+#include "blackmisc/aviation/flightplanaircraftinfo.h"
+#include "test.h"
+#include <QTest>
+
+using namespace BlackMisc::Aviation;
+
+namespace BlackMiscTest
+{
+    //! Flightplan unit tests
+    class CTestFlightPlanAircraftInfo : public QObject
+    {
+        Q_OBJECT
+
+    private slots:
+        //! Convert ICAO equipment code to CFlightPlanAircraftInfo and vice versa
+        void icaoConvert();
+
+        //! Convert FAA equipment code to CFlightPlanAircraftInfo and vice versa
+        void faaConvert();
+
+        //! Convert non FAA/ICAO equipment code to CFlightPlanAircraftInfo and vice versa
+        void nonValidConvert();
+
+    private:
+        struct TestEntry
+        {
+            QString m_icaoEquipment;
+            QString m_faaEquipment;
+            QString m_aircraftIcao;
+            CWakeTurbulenceCategory m_wtc;
+            CComNavEquipment m_equipment;
+            CSsrEquipment m_ssrEquipment;
+        };
+
+        QList<TestEntry> m_testEntries {
+            { "B737/M-SDE2E3FGHIRWXY/LB1",
+              "B737/L",
+              "B737",
+              CWakeTurbulenceCategory::MEDIUM,
+              CComNavEquipment(CComNavEquipment::ComNavEquipment(CComNavEquipment::Standard | CComNavEquipment::Dme | CComNavEquipment::DFisAcars | CComNavEquipment::PdcAcars | CComNavEquipment::Adf | CComNavEquipment::Gnss | CComNavEquipment::HfRtf | CComNavEquipment::InertiaNavigation | CComNavEquipment::Pbn | CComNavEquipment::Rvsm | CComNavEquipment::Mnps | CComNavEquipment::Vhf833),
+                               CComNavEquipment::CpdlcSatcomEquipment()),
+              CSsrEquipment::SSrEquipment(CSsrEquipment::ModeSTypeL | CSsrEquipment::AdsBB1) },
+            { "B748/H-SDE3FGHIM1M2RWXY/LB1",
+              "H/B748/L",
+              "B748",
+              CWakeTurbulenceCategory::HEAVY,
+              CComNavEquipment(CComNavEquipment::ComNavEquipment(CComNavEquipment::Standard | CComNavEquipment::Dme | CComNavEquipment::PdcAcars | CComNavEquipment::Adf | CComNavEquipment::Gnss | CComNavEquipment::HfRtf | CComNavEquipment::InertiaNavigation | CComNavEquipment::Pbn | CComNavEquipment::Rvsm | CComNavEquipment::Mnps | CComNavEquipment::Vhf833),
+                               CComNavEquipment::CpdlcSatcomEquipment(CComNavEquipment::AtcSatvoiceInmarsat | CComNavEquipment::AtcSatvoiceMtsat)),
+              CSsrEquipment::SSrEquipment(CSsrEquipment::ModeSTypeL | CSsrEquipment::AdsBB1) },
+            { "C172/L-DGV/C",
+              "C172/G",
+              "C172",
+              CWakeTurbulenceCategory::LIGHT,
+              CComNavEquipment(CComNavEquipment::ComNavEquipment(CComNavEquipment::VhfRtf | CComNavEquipment::Gnss | CComNavEquipment::Dme),
+                               CComNavEquipment::CpdlcSatcomEquipment()),
+              CSsrEquipment::SSrEquipment(CSsrEquipment::ModeAC) },
+            { "A388/J-SADE2E3FGHIJ3J4J5M1RWXY/LB1D1",
+              "J/A388/L",
+              "A388",
+              CWakeTurbulenceCategory::SUPER,
+              CComNavEquipment(CComNavEquipment::ComNavEquipment(CComNavEquipment::Standard | CComNavEquipment::Gbas | CComNavEquipment::Dme | CComNavEquipment::DFisAcars | CComNavEquipment::PdcAcars | CComNavEquipment::Adf | CComNavEquipment::Gnss | CComNavEquipment::HfRtf | CComNavEquipment::InertiaNavigation | CComNavEquipment::Pbn | CComNavEquipment::Rvsm | CComNavEquipment::Mnps | CComNavEquipment::Vhf833),
+                               CComNavEquipment::CpdlcSatcomEquipment(CComNavEquipment::CpdlcFansVdlA | CComNavEquipment::CpdlcFansVdl2 | CComNavEquipment::CpdlcFansSatcomInmarsat | CComNavEquipment::AtcSatvoiceInmarsat)),
+              CSsrEquipment::SSrEquipment(CSsrEquipment::ModeSTypeL | CSsrEquipment::AdsBB1 | CSsrEquipment::AdsCD1) }
+        };
+    };
+
+    void CTestFlightPlanAircraftInfo::icaoConvert()
+    {
+        for (const TestEntry &entry : m_testEntries)
+        {
+            CFlightPlanAircraftInfo info(entry.m_icaoEquipment);
+
+            QVERIFY2(info.getAircraftIcao().hasDesignator(), "Should have designator");
+            QVERIFY2(info.getAircraftIcao().getDesignator() == entry.m_aircraftIcao, "Should have same aircraft ICAO code");
+            QCOMPARE(info.getWtc(), entry.m_wtc);
+            QCOMPARE(info.getComNavEquipment(), entry.m_equipment);
+            QCOMPARE(info.getSsrEquipment(), entry.m_ssrEquipment);
+            QCOMPARE(info.asIcaoString(), entry.m_icaoEquipment);
+        }
+    }
+
+    void CTestFlightPlanAircraftInfo::faaConvert()
+    {
+        for (const TestEntry &entry : m_testEntries)
+        {
+            CFlightPlanAircraftInfo info(entry.m_faaEquipment);
+
+            QVERIFY2(info.getAircraftIcao().hasDesignator(), "Should have designator");
+            QCOMPARE(info.getAircraftIcao().getDesignator(), entry.m_aircraftIcao);
+
+            // FAA code only contains information about heavy and super wake turbulence category
+            if (entry.m_wtc.isCategory(CWakeTurbulenceCategory::HEAVY) || entry.m_wtc.isCategory(CWakeTurbulenceCategory::SUPER))
+            {
+                QCOMPARE(info.getWtc(), entry.m_wtc);
+            }
+            else
+            {
+                QVERIFY2(info.getWtc().isUnknown(), "Should have UNKNOWN wake turbulence category");
+            }
+
+            // Cannot compare COM/NAV equipment and SSR equipment as the FAA code does not contain that much detail
+
+            QCOMPARE(info.asFaaString(), entry.m_faaEquipment);
+        }
+    }
+
+    void CTestFlightPlanAircraftInfo::nonValidConvert()
+    {
+        // Missing WTC and equipment code
+        CFlightPlanAircraftInfo info("A388");
+        QCOMPARE(info.asFaaString(), "A388/X");
+        QCOMPARE(info.asIcaoString(), "A388/M-S/N");
+
+        // FAA format: Missing equipment code
+        info = CFlightPlanAircraftInfo("J/A388");
+        QCOMPARE(info.asFaaString(), "J/A388/X");
+        QCOMPARE(info.asIcaoString(), "A388/J-S/N");
+
+        // FAA format: Wrong aircraft ICAO (but correct length according to CAircraftIcaoCode::isValidDesignator)
+        info = CFlightPlanAircraftInfo("H/A1/W");
+        QCOMPARE(info.asFaaString(), "H/A1/W");
+        QCOMPARE(info.asIcaoString(), "A1/H-W/C");
+
+        // FAA format: Missing aircraft ICAO with WTC
+        info = CFlightPlanAircraftInfo("H//W");
+        QCOMPARE(info.asFaaString(), "H//W");
+        QCOMPARE(info.asIcaoString(), "/H-W/C");
+
+        // FAA format: Equipment code only
+        info = CFlightPlanAircraftInfo("/W");
+        QCOMPARE(info.asFaaString(), "/W");
+        QCOMPARE(info.asIcaoString(), "/M-W/C");
+
+        // Wrong aircraft ICAO (too short) without WTC and equipment
+        info = CFlightPlanAircraftInfo("X");
+        QCOMPARE(info.asFaaString(), "/X");
+        QCOMPARE(info.asIcaoString(), "/M-S/N");
+
+        // Wrong aircraft ICAO (too long) without WTC and equipment
+        info = CFlightPlanAircraftInfo("ABCDEFGHIJKL");
+        QCOMPARE(info.asFaaString(), "/X");
+        QCOMPARE(info.asIcaoString(), "/M-S/N");
+
+        // Empty
+        info = CFlightPlanAircraftInfo("");
+        QCOMPARE(info.asFaaString(), "/X");
+        QCOMPARE(info.asIcaoString(), "/M-S/N");
+
+        // FAA format: Lower case (all)
+        info = CFlightPlanAircraftInfo("h/b744/L");
+        QCOMPARE(info.asFaaString(), "H/B744/L");
+        QCOMPARE(info.asIcaoString(), "B744/H-GW/C");
+
+        // FAA format: Lower case without WTC
+        info = CFlightPlanAircraftInfo("b738/w");
+        QCOMPARE(info.asFaaString(), "B738/W");
+        QCOMPARE(info.asIcaoString(), "B738/M-W/C");
+
+        // Lower case without WTC and equipment
+        info = CFlightPlanAircraftInfo("dh8d");
+        QCOMPARE(info.asFaaString(), "DH8D/X");
+        QCOMPARE(info.asIcaoString(), "DH8D/M-S/N");
+
+        // FAA format: Invalid WTC
+        info = CFlightPlanAircraftInfo("Q/A346");
+        QCOMPARE(info.asFaaString(), "A346/X");
+        QCOMPARE(info.asIcaoString(), "A346/M-S/N");
+
+        // FAA format: Leading whitespace
+        info = CFlightPlanAircraftInfo(" H/B748/L");
+        QCOMPARE(info.asFaaString(), "H/B748/L");
+        QCOMPARE(info.asIcaoString(), "B748/H-GW/C");
+
+        // FAA format: Trailing whitespace
+        info = CFlightPlanAircraftInfo("H/B748/L ");
+        QCOMPARE(info.asFaaString(), "H/B748/L");
+        QCOMPARE(info.asIcaoString(), "B748/H-GW/C");
+
+        // FAA format: Whitespaces in between
+        info = CFlightPlanAircraftInfo("H / B7 48 /L");
+        QCOMPARE(info.asFaaString(), "H/B748/L");
+        QCOMPARE(info.asIcaoString(), "B748/H-GW/C");
+
+        // ICAO format: Invalid WTC
+        info = CFlightPlanAircraftInfo("A339/?-S/N");
+        QCOMPARE(info.asFaaString(), "A339/X");
+        QCOMPARE(info.asIcaoString(), "A339/M-S/N");
+
+        // ICAO format: Missing SSR equipment code
+        info = CFlightPlanAircraftInfo("A339/H-S");
+        QCOMPARE(info.asFaaString(), "A339/X");
+        QCOMPARE(info.asIcaoString(), "A339/M-S/N");
+
+        // ICAO format: Lowercase
+        info = CFlightPlanAircraftInfo("b737/m-sde2e3fghirwxy/lb1");
+        QCOMPARE(info.asFaaString(), "B737/L");
+        QCOMPARE(info.asIcaoString(), "B737/M-SDE2E3FGHIRWXY/LB1");
+
+        // ICAO format: Leading whitespace
+        info = CFlightPlanAircraftInfo(" B737/M-SDE2E3FGHIRWXY/LB1");
+        QCOMPARE(info.asFaaString(), "B737/L");
+        QCOMPARE(info.asIcaoString(), "B737/M-SDE2E3FGHIRWXY/LB1");
+
+        // ICAO format: Trailing whitespace
+        info = CFlightPlanAircraftInfo("B737/M-SDE2E3FGHIRWXY/LB1 ");
+        QCOMPARE(info.asFaaString(), "B737/L");
+        QCOMPARE(info.asIcaoString(), "B737/M-SDE2E3FGHIRWXY/LB1");
+
+        // ICAO format: Whitespaces in between
+        info = CFlightPlanAircraftInfo("B737/ M - SDE2E3FGH IRWXY / LB1");
+        QCOMPARE(info.asFaaString(), "B737/L");
+        QCOMPARE(info.asIcaoString(), "B737/M-SDE2E3FGHIRWXY/LB1");
+    }
+
+} // ns
+
+//! main
+BLACKTEST_APPLESS_MAIN(BlackMiscTest::CTestFlightPlanAircraftInfo);
+
+#include "testflightplanaircraftinfo.moc"
+
+//! \endcond


### PR DESCRIPTION
Fixes #124

With this PR, swift internally always uses ICAO equipment codes. If FAA codes are required (receiving or sending to a server that does not support them; this is controlled with a new FSD option), the ICAO codes are translated to FAA codes accordingly.
