### PR TITLE
Disable processing incoming velocity packets

### DIFF
--- a/src/blackcore/fsd/fsdclient.cpp
+++ b/src/blackcore/fsd/fsdclient.cpp
@@ -1282,8 +1282,9 @@ namespace BlackCore::Fsd
         emit euroscopeSimDataUpdatedReceived(situation, parts, currentOffsetTime(data.sender()), data.m_model, data.m_livery);
     }
 
-    void CFSDClient::handleVisualPilotDataUpdate(const QStringList &tokens, MessageType messageType)
+    void CFSDClient::handleVisualPilotDataUpdate(const QStringList & /*tokens*/, MessageType /*messageType*/)
     {
+#if 0
         VisualPilotDataUpdate dataUpdate;
         switch (messageType)
         {
@@ -1312,6 +1313,7 @@ namespace BlackCore::Fsd
         situation.setTimeOffsetMs(offsetTimeMs);
 
         emit visualPilotDataUpdateReceived(situation);
+#endif
     }
 
     void CFSDClient::handleVisualPilotDataToggle(const QStringList &tokens)

--- a/src/blackcore/fsd/fsdclient.cpp
+++ b/src/blackcore/fsd/fsdclient.cpp
@@ -1909,7 +1909,6 @@ namespace BlackCore::Fsd
 
     qint64 CFSDClient::receivedPositionFixTsAndGetOffsetTime(const CCallsign &callsign, qint64 markerTs)
     {
-        // \fixme This logic should be in a different class
         Q_ASSERT_X(!callsign.isEmpty(), Q_FUNC_INFO, "Need callsign");
 
         if (markerTs < 0) { markerTs = QDateTime::currentMSecsSinceEpoch(); }
@@ -1927,25 +1926,13 @@ namespace BlackCore::Fsd
 
         int count = 0;
         const qint64 avgTimeMs = this->averageOffsetTimeMs(callsign, count, 3); // latest average
-        qint64 targetOffsetTime = CFsdSetup::c_positionTimeOffsetMsec;
+        qint64 offsetTime = CFsdSetup::c_positionTimeOffsetMsec;
 
         if (avgTimeMs < CFsdSetup::c_minimumPositionTimeOffsetMsec && count >= 3)
         {
-            targetOffsetTime = CFsdSetup::c_minimumPositionTimeOffsetMsec;
+            offsetTime = CFsdSetup::c_minimumPositionTimeOffsetMsec;
         }
 
-        const qint64 previousInterpolatedOffsetTime = m_interpolatedOffsetTime.value(callsign, 0);
-        qint64 offsetDiff = 0;
-        if (targetOffsetTime < previousInterpolatedOffsetTime)
-        {
-            offsetDiff = std::max(targetOffsetTime - previousInterpolatedOffsetTime, diff / -c_offsetTimeInterpolationInverseRate);
-        }
-        else
-        {
-            offsetDiff = std::min(targetOffsetTime - previousInterpolatedOffsetTime, diff / c_offsetTimeInterpolationInverseRate);
-        }
-        qint64 offsetTime = previousInterpolatedOffsetTime + offsetDiff;
-        m_interpolatedOffsetTime.insert(callsign, offsetTime);
         return m_additionalOffsetTime + offsetTime;
     }
 

--- a/src/blackcore/fsd/fsdclient.cpp
+++ b/src/blackcore/fsd/fsdclient.cpp
@@ -1928,9 +1928,9 @@ namespace BlackCore::Fsd
         const qint64 avgTimeMs = this->averageOffsetTimeMs(callsign, count, 3); // latest average
         qint64 offsetTime = CFsdSetup::c_positionTimeOffsetMsec;
 
-        if (avgTimeMs < CFsdSetup::c_minimumPositionTimeOffsetMsec && count >= 3)
+        if (avgTimeMs < CFsdSetup::c_interimPositionTimeOffsetMsec && count >= 3)
         {
-            offsetTime = CFsdSetup::c_minimumPositionTimeOffsetMsec;
+            offsetTime = CFsdSetup::c_interimPositionTimeOffsetMsec;
         }
 
         return m_additionalOffsetTime + offsetTime;

--- a/src/blackcore/fsd/fsdclient.h
+++ b/src/blackcore/fsd/fsdclient.h
@@ -575,8 +575,6 @@ namespace BlackCore::Fsd
         QHash<BlackMisc::Aviation::CCallsign, PendingAtisQuery> m_pendingAtisQueries;
         QHash<BlackMisc::Aviation::CCallsign, qint64> m_lastPositionUpdate;
         QHash<BlackMisc::Aviation::CCallsign, QList<qint64>> m_lastOffsetTimes; //!< latest offset first
-        QHash<BlackMisc::Aviation::CCallsign, qint64> m_interpolatedOffsetTime;
-        static const int c_offsetTimeInterpolationInverseRate = 4;
 
         BlackMisc::Aviation::CAtcStationList m_atcStations;
 

--- a/src/blackmisc/network/fsdsetup.h
+++ b/src/blackmisc/network/fsdsetup.h
@@ -60,7 +60,7 @@ namespace BlackMisc::Network
         //! Offset times basically telling when to expect the next value from network plus some reserve
         //! \remark related to CNetworkVatlib::c_updatePostionIntervalMsec / c_updateInterimPostionIntervalMsec
         static constexpr qint64 c_positionTimeOffsetMsec = 6000; //!< offset time for received position updates Ref T297
-        static constexpr qint64 c_minimumPositionTimeOffsetMsec = 700; //!< offset time for vatsim high frequency position updates
+        static constexpr qint64 c_interimPositionTimeOffsetMsec = 1500; //!< offset time for received interim position updates Ref T297
         //! @}
 
         //! Default constructor.

--- a/src/blackmisc/simulation/interpolatorspline.cpp
+++ b/src/blackmisc/simulation/interpolatorspline.cpp
@@ -126,7 +126,7 @@ namespace BlackMisc::Simulation
         }
 
         // set some default values
-        const qint64 os = qMax(CFsdSetup::c_minimumPositionTimeOffsetMsec, m_s[2].getTimeOffsetMs());
+        const qint64 os = qMax(CFsdSetup::c_interimPositionTimeOffsetMsec, m_s[2].getTimeOffsetMs());
         m_s[0].addMsecs(-os); // oldest, Ref T297 default offset time to fill data
         m_s[2].addMsecs(os); // latest, Ref T297 default offset time to fill data
         if (m_currentSituations.isEmpty()) { return false; }


### PR DESCRIPTION
After some tests, this will remove the warping aircraft issue. Processing the ``VisualPilotDataUpdate`` packets will be re-enabled later when adding a Velocity-based interpolator with #241. 