### PR TITLE
Fix xswiftbus RUNPATH and remove Win32 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,98 +270,6 @@ jobs:
           name: xswiftbus-thin-windows-64-${{ needs.preBuild.outputs.version }}
           path: ${{ github.workspace }}/xswiftbus-*
 
-  buildWin32:
-    runs-on: windows-2022
-    needs: [preBuild, checks]
-    env:
-      BACKTRACE_SYMBOL_TOKEN: ${{ secrets.BACKTRACE_SYMBOL_TOKEN }}
-      BACKTRACE_MINIDUMP_TOKEN: ${{ secrets.BACKTRACE_MINIDUMP_TOKEN }}
-      BITROCK_BUILDER: "~/installbuilder/bin/builder-cli.exe"
-
-    steps:
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v3
-        with:
-          version: ${{ env.qt_version }}
-          arch: win32_msvc2019
-          cache: true
-      - name: Install Qt debug info
-        uses: jurplel/install-qt-action@v3
-        with:
-          version: ${{ env.qt_version }}
-          arch: win32_msvc2019
-          cache: true
-          modules: debug_info
-          extra: --archives qtbase
-      - name: Cache InstallBuilder
-        id: cache-bitrock
-        uses: actions/cache@v4
-        with:
-          path: C:\installbuilder.exe
-          key: installbuilder-${{ env.bitrock_version }}-windows
-      - name: Download InstallBuilder
-        if: steps.cache-bitrock.outputs.cache-hit != 'true'
-        shell: C:\msys64\usr\bin\bash.exe -le {0}
-        run: |
-          wget --retry-connrefused -t 10 -w 10 -T 60 -O /c/installbuilder.exe ${{ env.bitrock_url }}/installbuilder-${{ env.bitrock_version }}-windows-installer.exe
-        env:
-          MSYSTEM: MSYS2
-      - name: Install InstallBuilder
-        run: |
-          start -wait "C:\installbuilder.exe" @("--mode", "unattended", "--prefix", "$HOME\installbuilder")
-          echo >$HOME\license.xml @"
-          $env:BITROCK_LICENSE
-          "@
-        env:
-          BITROCK_LICENSE: ${{ secrets.BITROCK_LICENSE }}
-      - name: Install dependencies
-        run: |
-          pip install requests PyInstaller
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-      - name: Checkout externals
-        if: ${{ env.use_externals == 'true' }}
-        uses: actions/checkout@v4
-        env:
-          EXTERNALS_PAT: ${{ secrets.EXTERNALS_PAT }}
-        with:
-          repository: ${{ env.externals }}
-          ref: ${{ env.externals_sha }}
-          token: ${{ env.EXTERNALS_PAT }}
-          path: 'third_party/externals'
-      - name: Create Vatsim key file
-        if: ${{ env.do_vatsim_key == 'true' }}
-        run: |
-          echo >vatsim.json @"
-          { "vatsim": { "id": "$env:VATSIM_ID", "key": "$env:VATSIM_KEY" } }
-          "@
-        env:
-          VATSIM_ID: ${{ secrets.VATSIM_ID }}
-          VATSIM_KEY: ${{ secrets.VATSIM_KEY }}
-      - uses: Trass3r/setup-cpp@1b63900ecf3f0b7c60ee53aa7be122f2c4fe7a2c
-      - name: Build swift (without symbols)
-        if: ${{ env.do_symbols != 'true' }}
-        run: |
-          python -u scripts/build.py -w 32 -t msvc
-      - name: Build swift (with symbols)
-        if: ${{ env.do_symbols == 'true' }}
-        run: |
-          python -u scripts/build.py -w 32 -t msvc --upload-symbols
-      - name: Upload installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: swiftinstaller-windows-32-${{ needs.preBuild.outputs.version }}
-          path: ${{ github.workspace }}/swiftinstaller-*
-      - name: Upload symbols
-        uses: actions/upload-artifact@v4
-        if: ${{ env.do_symbols == 'true' }}
-        with:
-          name: swiftsymbols-windows-32-${{ needs.preBuild.outputs.version }}
-          path: ${{ github.workspace }}/swiftsymbols-*
-
   buildMacOS:
     runs-on: macos-12
     needs: [preBuild, checks]
@@ -456,7 +364,7 @@ jobs:
 
   postBuild:
     runs-on: ubuntu-22.04
-    needs: [preBuild, checks, buildLinux, buildWin64, buildWin32, buildMacOS]
+    needs: [preBuild, checks, buildLinux, buildWin64, buildMacOS]
 
     steps:
       - name: Download xswiftbus-thin
@@ -515,7 +423,6 @@ jobs:
           files: >
             swiftinstaller-linux-64-${{ needs.preBuild.outputs.version }}.run
             swiftinstaller-windows-64-${{ needs.preBuild.outputs.version }}.exe
-            swiftinstaller-windows-32-${{ needs.preBuild.outputs.version }}.exe
             swiftinstaller-macos-64-${{ needs.preBuild.outputs.version }}.dmg
             xswiftbus-fat-allos-${{ needs.preBuild.outputs.version }}.7z
             swiftsymbols-allos-${{ needs.preBuild.outputs.version }}:swiftsymbols
@@ -524,7 +431,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-22.04
-    needs: [preBuild, checks, buildLinux, buildWin64, buildWin32, buildMacOS, postBuild, release]
+    needs: [preBuild, checks, buildLinux, buildWin64, buildMacOS, postBuild, release]
     if: always()
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   do_vatsim_key: ${{ github.event_name == 'push' }}
   do_symbols:    ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   qt_version:    5.15.2
-  bitrock_version: qt-professional-23.11.0
+  bitrock_version: qt-professional-24.7.0
   bitrock_url:     https://releases.installbuilder.com/installbuilder
   externals: swift-project/externals
   externals_sha: 53e671fc3ba76f2036b9130314507776d161c6e0

--- a/cmake/event/CMakeLists.txt
+++ b/cmake/event/CMakeLists.txt
@@ -24,6 +24,8 @@ else()
         set(LIBEVENT_CORE_ABS "${dir}/${LIBEVENT_CORE_ABS}")
     endif()
 
+    string(REGEX MATCH "libevent_core-2.1.so.[1-9]+" SOMAJOR_VERSION ${LIBEVENT_CORE_ABS})
+    set_target_properties(externals_event PROPERTIES IMPORTED_SONAME ${SOMAJOR_VERSION})
     set_target_properties(externals_event PROPERTIES IMPORTED_LOCATION ${LIBEVENT_CORE_ABS})
 endif()
 

--- a/src/xswiftbus/CMakeLists.txt
+++ b/src/xswiftbus/CMakeLists.txt
@@ -158,6 +158,8 @@ target_compile_definitions(xswiftbus PUBLIC XSWIFTBUS_VERSION="${swift_version_m
 
 if(APPLE)
     set_target_properties(xswiftbus PROPERTIES INSTALL_RPATH @loader_path/)
+elseif(UNIX)
+    set_target_properties(xswiftbus PROPERTIES INSTALL_RPATH $ORIGIN)
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/xswiftbus_tools.cmake)


### PR DESCRIPTION
Qt6 is not officially supported for x86. Hence, this PR removes the x86 build. Perhaps support for FS9, FSX and P3Dv1-3 will be added back to swift at a later point.